### PR TITLE
fix: critical bugs and performance optimizations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "fmt"]
 	path = fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "nanobench"]
+	path = nanobench
+	url = https://github.com/martinus/nanobench.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(fmt/include)
 # Add subdirectories
 add_subdirectory(src)
 add_subdirectory(tests)
+add_subdirectory(bench)
 if(NOT TARGET fmt::fmt)
     add_subdirectory(fmt)
 endif()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10)
+
+add_executable(arena_bench EXCLUDE_FROM_ALL arena_bench.cc)
+
+target_include_directories(arena_bench PRIVATE
+    ${CMAKE_SOURCE_DIR}/nanobench/src/include
+)
+
+target_compile_options(arena_bench PRIVATE
+    -O3
+    -DNDEBUG
+    -march=native
+    -frtti
+)
+
+target_link_libraries(arena_bench arena)

--- a/bench/arena_bench.cc
+++ b/bench/arena_bench.cc
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2024 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "nanobench.h"
+
+#include "arena/arena.hpp"
+
+#include <cstdlib>
+#include <memory>
+#include <memory_resource>
+#include <random>
+#include <vector>
+
+using namespace arena;
+namespace nb = ankerl::nanobench;
+
+// Test object with destructor
+struct TestObject {
+  int data[4];
+  ArenaFullManagedTag;
+  TestObject() { data[0] = 42; }
+  ~TestObject() { data[0] = 0; }
+};
+
+// Test object without destructor registration
+struct SimpleObject {
+  int data[4];
+  ArenaManagedCreateOnlyTag;
+  SimpleObject() { data[0] = 42; }
+  ~SimpleObject() = default;
+};
+
+int main() {
+  std::cout << "======================================================\n";
+  std::cout << "           Arena vs Malloc Benchmark Suite\n";
+  std::cout << "======================================================\n\n";
+
+  // ========================================================================
+  // Benchmark 1: Small allocations (32 bytes)
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Small Allocation (32B)")
+        .warmup(1000)
+        .minEpochIterations(100000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena::AllocateAligned", [&]() {
+      void *p = arena.AllocateAligned(32);
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<void *> ptrs;
+    ptrs.reserve(1000000);
+    bench.run("malloc", [&]() {
+      void *p = std::malloc(32);
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      std::free(p);
+  }
+
+  // ========================================================================
+  // Benchmark 2: Medium allocations (512 bytes)
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Medium Allocation (512B)")
+        .warmup(1000)
+        .minEpochIterations(50000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena::AllocateAligned", [&]() {
+      void *p = arena.AllocateAligned(512);
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<void *> ptrs;
+    ptrs.reserve(500000);
+    bench.run("malloc", [&]() {
+      void *p = std::malloc(512);
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      std::free(p);
+  }
+
+  // ========================================================================
+  // Benchmark 3: Large allocations (4KB)
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Large Allocation (4KB)").warmup(100).minEpochIterations(10000);
+
+    Arena::Options opts = Arena::Options::GetDefaultOptions();
+    opts.huge_block_size = 64 * 1024 * 1024;
+    Arena arena(opts);
+    bench.run("Arena::AllocateAligned", [&]() {
+      void *p = arena.AllocateAligned(4096);
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<void *> ptrs;
+    ptrs.reserve(100000);
+    bench.run("malloc", [&]() {
+      void *p = std::malloc(4096);
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      std::free(p);
+  }
+
+  // ========================================================================
+  // Benchmark 4: Batch allocation + reset/free (key Arena use case)
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Batch Alloc+Free (64B x 1000)")
+        .warmup(100)
+        .minEpochIterations(1000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena + Reset", [&]() {
+      for (int i = 0; i < 1000; ++i) {
+        void *p = arena.AllocateAligned(64);
+        nb::doNotOptimizeAway(p);
+      }
+      arena.Reset();
+    });
+
+    bench.run("malloc + free", [&]() {
+      std::vector<void *> ptrs;
+      ptrs.reserve(1000);
+      for (int i = 0; i < 1000; ++i) {
+        void *p = std::malloc(64);
+        nb::doNotOptimizeAway(p);
+        ptrs.push_back(p);
+      }
+      for (auto *p : ptrs)
+        std::free(p);
+    });
+  }
+
+  // ========================================================================
+  // Benchmark 5: Object creation with destructor
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Object Create<T> with destructor")
+        .warmup(1000)
+        .minEpochIterations(50000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena::Create<T>", [&]() {
+      auto *p = arena.Create<TestObject>();
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<TestObject *> ptrs;
+    ptrs.reserve(500000);
+    bench.run("new T", [&]() {
+      auto *p = new TestObject();
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      delete p;
+  }
+
+  // ========================================================================
+  // Benchmark 6: Object creation without destructor
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Object Create<T> skip destructor")
+        .warmup(1000)
+        .minEpochIterations(50000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena::Create<T>", [&]() {
+      auto *p = arena.Create<SimpleObject>();
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<SimpleObject *> ptrs;
+    ptrs.reserve(500000);
+    bench.run("new T", [&]() {
+      auto *p = new SimpleObject();
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      delete p;
+  }
+
+  // ========================================================================
+  // Benchmark 7: PMR vector operations
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Vector push_back x100").warmup(100).minEpochIterations(10000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("pmr::vector + Arena", [&]() {
+      std::pmr::vector<int> vec(arena.get_memory_resource());
+      for (int i = 0; i < 100; ++i) {
+        vec.push_back(i);
+      }
+      nb::doNotOptimizeAway(vec.data());
+    });
+
+    bench.run("std::vector", [&]() {
+      std::vector<int> vec;
+      for (int i = 0; i < 100; ++i) {
+        vec.push_back(i);
+      }
+      nb::doNotOptimizeAway(vec.data());
+    });
+  }
+
+  // ========================================================================
+  // Benchmark 8: Mixed size allocations
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Mixed Sizes (8-1024B)").warmup(1000).minEpochIterations(50000);
+
+    std::vector<size_t> sizes = {8, 16, 32, 64, 128, 256, 512, 1024};
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<size_t> dist(0, sizes.size() - 1);
+
+    std::vector<size_t> random_sizes;
+    random_sizes.reserve(100000);
+    for (int i = 0; i < 100000; ++i) {
+      random_sizes.push_back(sizes[dist(rng)]);
+    }
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    size_t idx = 0;
+    bench.run("Arena::AllocateAligned", [&]() {
+      void *p =
+          arena.AllocateAligned(random_sizes[idx++ % random_sizes.size()]);
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<void *> ptrs;
+    ptrs.reserve(500000);
+    idx = 0;
+    bench.run("malloc", [&]() {
+      void *p = std::malloc(random_sizes[idx++ % random_sizes.size()]);
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      std::free(p);
+  }
+
+  // ========================================================================
+  // Benchmark 9: Allocation with memory touch
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Alloc + memset (64B)").warmup(1000).minEpochIterations(50000);
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena + touch", [&]() {
+      char *p = arena.AllocateAligned(64);
+      for (int i = 0; i < 64; i += 8) {
+        p[i] = static_cast<char>(i);
+      }
+      nb::doNotOptimizeAway(p);
+    });
+
+    std::vector<void *> ptrs;
+    ptrs.reserve(500000);
+    bench.run("malloc + touch", [&]() {
+      char *p = static_cast<char *>(std::malloc(64));
+      for (int i = 0; i < 64; i += 8) {
+        p[i] = static_cast<char>(i);
+      }
+      nb::doNotOptimizeAway(p);
+      ptrs.push_back(p);
+    });
+    for (auto *p : ptrs)
+      std::free(p);
+  }
+
+  // ========================================================================
+  // Benchmark 10: Sequential pattern (simulates parsing)
+  // ========================================================================
+  {
+    nb::Bench bench;
+    bench.title("Parse Pattern (100 mixed allocs + reset/free)")
+        .warmup(100)
+        .minEpochIterations(1000);
+
+    std::vector<size_t> pattern = {16, 32, 8, 64, 16, 128, 32, 16, 8, 256};
+
+    Arena arena(Arena::Options::GetDefaultOptions());
+    bench.run("Arena + Reset", [&]() {
+      for (int i = 0; i < 100; ++i) {
+        void *p = arena.AllocateAligned(pattern[i % pattern.size()]);
+        nb::doNotOptimizeAway(p);
+      }
+      arena.Reset();
+    });
+
+    bench.run("malloc + free", [&]() {
+      std::vector<void *> ptrs;
+      ptrs.reserve(100);
+      for (int i = 0; i < 100; ++i) {
+        void *p = std::malloc(pattern[i % pattern.size()]);
+        nb::doNotOptimizeAway(p);
+        ptrs.push_back(p);
+      }
+      for (auto *p : ptrs)
+        std::free(p);
+    });
+  }
+
+  std::cout << "\n======================================================\n";
+  std::cout << "                    Benchmark Complete\n";
+  std::cout << "======================================================\n";
+  std::cout << "\nNotes:\n";
+  std::cout << "  - Lower time is better\n";
+  std::cout << "  - Arena excels at batch allocations with Reset()\n";
+  std::cout << "  - Results vary based on system allocator\n";
+  std::cout << "  - Run with: ./arena_bench for detailed results\n\n";
+
+  return 0;
+}

--- a/include/arena/arena.hpp
+++ b/include/arena/arena.hpp
@@ -17,71 +17,71 @@
 #pragma once
 
 #include <memory_resource>
-#include <stdint.h>  // for uint64_t, uint8_t
+#include <stdint.h> // for uint64_t, uint8_t
 
-#include <cassert>    // for assert macro
+#include <cassert> // for assert macro
 #include <concepts>
 #include <cstdint>
-#include <cstdlib>    // for free, malloc, size_t
-#include <exception>  // for type_info
+#include <cstdlib>   // for free, malloc, size_t
+#include <exception> // for type_info
 #include <fmt/format.h>
-#include <iostream>       // for endl, basic_ostream, cerr
-#include <limits>         // for numeric_limits
-#include <new>            // for operator new, bad_alloc
-#include <string>         // for allocator, operator<<, string
-#include <type_traits>    // for false_type, is_standard_layout
-#include <typeinfo>       // for bad_cast, type_info
-#include <unordered_map>  // for polymorphic_allocator
-#include <utility>        // for exchange, forward
+#include <iostream>        // for endl, basic_ostream, cerr
+#include <limits>          // for numeric_limits
+#include <new>             // for operator new, bad_alloc
+#include <source_location> // for source_location, current
+#include <string>          // for allocator, operator<<, string
+#include <type_traits>     // for false_type, is_standard_layout
+#include <typeinfo>        // for bad_cast, type_info
+#include <unordered_map>   // for polymorphic_allocator
+#include <utility>         // for exchange, forward
 #include <variant>
-#include <source_location>  // for source_location, current
 
-#include "arena/align.hpp"  // for AlignUpTo
-#include "arena/arenahelper.hpp"  // for ArenaHelper
+#include "arena/align.hpp"       // for AlignUpTo
+#include "arena/arenahelper.hpp" // for ArenaHelper
 
 #ifndef Assert
-#define Assert(cond, msg) assert((cond) && msg)  // NOLINT
+#define Assert(cond, msg) assert((cond) && msg) // NOLINT
 #endif
 
 namespace arena {
 
+using align::AlignUpTo;
 using ::std::size_t;
 using ::std::type_info;
-using align::AlignUpTo;
 using std::pmr::memory_resource;
 
-static void default_logger_func(const std::string& output) { std::cerr << output << std::endl; }
+static void default_logger_func(const std::string &output) {
+  std::cerr << output << std::endl;
+}
 
 /*
  * CleanupNode class store the cleanup closure in 128bits.
  * element store the obj.
  * cleanup store the destructor ptr.
  */
-struct CleanupNode
-{
-    void* element;
-    void (*cleanup)(void*);
+struct CleanupNode {
+  void *element;
+  void (*cleanup)(void *);
 };
 
 inline constexpr uint64_t kByteSize = 8;
 inline constexpr uint64_t kInt256Size = 32;
 inline constexpr uint64_t kByteSizeMask = kByteSize - 1;
-static constexpr uint64_t kCleanupNodeSize = AlignUpTo<kByteSize>(static_cast<uint64_t>(sizeof(arena::CleanupNode)));
+static constexpr uint64_t kCleanupNodeSize =
+    AlignUpTo<kByteSize>(static_cast<uint64_t>(sizeof(arena::CleanupNode)));
 
 /*
  * destructor closure of type T
  */
-template <typename T>
-void arena_destruct_object(void* obj) noexcept {
-    reinterpret_cast<T*>(obj)->~T();
+template <typename T> void arena_destruct_object(void *obj) noexcept {
+  reinterpret_cast<T *>(obj)->~T();
 }
 
 /*
  * delete closure of type T
  */
-template <typename T>
-void arena_delete_object(void* obj) noexcept {
-    delete reinterpret_cast<T*>(obj);
+template <typename T> void arena_delete_object(void *obj) noexcept {
+  delete reinterpret_cast<T *>(obj);
 }
 
 inline constexpr uint64_t kKiloByte = 1024;
@@ -92,8 +92,10 @@ inline constexpr uint64_t kMegaByte = 1024 * 1024;
  * otherwise it is a pmr container.
  */
 template <typename T>
-concept Creatable = Constructable<T> || (std::is_standard_layout<T>::value && std::is_trivial<T>::value) ||
-                    std::is_constructible_v<T, std::pmr::polymorphic_allocator<T>>;
+concept Creatable =
+    Constructable<T> ||
+    (std::is_standard_layout<T>::value && std::is_trivial<T>::value) ||
+    std::is_constructible_v<T, std::pmr::polymorphic_allocator<T>>;
 
 /*
  * TriviallyDestructible concept requires T just has default destructor.
@@ -101,17 +103,17 @@ concept Creatable = Constructable<T> || (std::is_standard_layout<T>::value && st
 template <typename T>
 concept TriviallyDestructible = std::is_trivially_destructible<T>::value;
 
-enum class ArenaContainStatus : uint8_t
-{
-    NotContain = 0,
-    BlockHeader,
-    BlockCleanup,
-    BlockUsed,
-    BlockUnUsed,
+enum class ArenaContainStatus : uint8_t {
+  NotContain = 0,
+  BlockHeader,
+  BlockCleanup,
+  BlockUsed,
+  BlockUnUsed,
 };
 /*
  * Arena is a session-ware allocator implementation,
- * it can be used to allocate memory blocks and de-allocate them in a single call.
+ * it can be used to allocate memory blocks and de-allocate them in a single
+ * call.
  *
  * Arena can make data-locality good as a c program.
  * Arena make sure the memory allocation will always be aligned.
@@ -122,555 +124,618 @@ enum class ArenaContainStatus : uint8_t
  * NOTICE:
  * Arena is not the best choice in everytime.
  * Arena will waste memory because of alignment;
- * Arena will allocate a large memory-block is a single allocation, and the block will not be give back to system pool
- * until Arena's destruction. A long-life-cycle Arena will make the system bearing memory starve, be care of the Arena's
- * life-cycle.
+ * Arena will allocate a large memory-block is a single allocation, and the
+ * block will not be give back to system pool until Arena's destruction. A
+ * long-life-cycle Arena will make the system bearing memory starve, be care of
+ * the Arena's life-cycle.
  *
- * Arena could be reused without destruction, just reset is ok, it will remain the first block and deallocate the
- * followings.
+ * Arena could be reused without destruction, just reset is ok, it will remain
+ * the first block and deallocate the followings.
  */
-class Arena
-{
-   public:
-    // make sure Arena can not be copyable
-    Arena(const Arena&) = delete;
-    auto operator=(const Arena&) -> Arena& = delete;
+class Arena {
+public:
+  // make sure Arena can not be copyable
+  Arena(const Arena &) = delete;
+  auto operator=(const Arena &) -> Arena & = delete;
 
-    [[gnu::always_inline]] inline Arena(Arena&& other) noexcept
-        : _options(other._options),
-          _last_block(std::exchange(other._last_block, nullptr)),
-          _resource(std::exchange(other._resource, nullptr)),
-          _cookie(std::exchange(other._cookie, nullptr)),
-          _space_allocated(std::exchange(other._space_allocated, 0)) {}
-    auto operator=(Arena&&) noexcept -> Arena& = delete;
+  [[gnu::always_inline]] inline Arena(Arena &&other) noexcept
+      : _options(other._options),
+        _last_block(std::exchange(other._last_block, nullptr)),
+        _resource(std::exchange(other._resource, nullptr)),
+        _cookie(std::exchange(other._cookie, nullptr)),
+        _space_allocated(std::exchange(other._space_allocated, 0)) {
+    // Fix: update resource's arena pointer to point to this (the new Arena)
+    if (_resource != nullptr) {
+      _resource->set_arena(this);
+    }
+  }
+  auto operator=(Arena &&) noexcept -> Arena & = delete;
 
-    /*
-     * Arena Options class for the Arena class' configuration.
-     * the Options' parameters should be tune by the OS/CPU special features, and the App's scenarios.
-     * only use size is align to pagesize in your environment.
-     */
-    struct Options
-    {
-        // normal_block_size should match normal page of the OS.
-        uint64_t normal_block_size;
+  /*
+   * Arena Options class for the Arena class' configuration.
+   * the Options' parameters should be tune by the OS/CPU special features, and
+   * the App's scenarios. only use size is align to pagesize in your
+   * environment.
+   */
+  struct Options {
+    // normal_block_size should match normal page of the OS.
+    uint64_t normal_block_size;
 
-        // huge_block_size should match big memory page of the OS.
-        uint64_t huge_block_size;
+    // huge_block_size should match big memory page of the OS.
+    uint64_t huge_block_size;
 
-        // suggested block-size, it should match your most recently memory usage.
-        uint64_t suggested_init_block_size;
+    // suggested block-size, it should match your most recently memory usage.
+    uint64_t suggested_init_block_size;
 
-        // A Function pointer to an alloc method for the new block in the Arena.
-        void* (*block_alloc)(std::size_t){nullptr};
+    // A Function pointer to an alloc method for the new block in the Arena.
+    void *(*block_alloc)(std::size_t){nullptr};
 
-        // A Function pointer to a dealloc method for the blocks in the Arena.
-        void (*block_dealloc)(void*){nullptr};
+    // A Function pointer to a dealloc method for the blocks in the Arena.
+    void (*block_dealloc)(void *){nullptr};
 
-        void (*logger_func)(const std::string&){nullptr};
+    void (*logger_func)(const std::string &){nullptr};
 
-        // Arena hooked functions
-        // Hooks for adding external functionality.
-        // Init hook may return a pointer to a cookie to be stored in the arena.
-        // reset and destruction hooks will then be called with the same cookie = delete
-        // pointer. This allows us to save an external object per arena instance and
-        // use it on the other hooks (Note: It is just as legal for init to return
-        // NULL and not use the cookie feature).
-        // on_arena_reset and on_arena_destruction also receive the space used in
-        // the arena just before the reset.
-        void* (*on_arena_init)(Arena* arena, const std::source_location& loc){nullptr};
-        void (*on_arena_reset)(Arena* arena, void* cookie, uint64_t space_used, uint64_t space_wasted){nullptr};
-        void (*on_arena_allocation)(const type_info* alloc_type, uint64_t alloc_size, void* cookie){nullptr};
-        void (*on_arena_newblock)(uint64_t blk_num, uint64_t blk_size, void* cookie){nullptr};
-        void* (*on_arena_destruction)(Arena* arena, void* cookie, uint64_t space_used, uint64_t space_wasted){nullptr};
-
-        /*
-         * A simplest function to get Options.
-         * just for testing or examples,
-         */
-        [[nodiscard, gnu::always_inline]] inline static auto GetDefaultOptions() -> Options {
-            return {
-              .normal_block_size = 4 * kKiloByte,
-              .huge_block_size = 2 * kMegaByte,
-              .suggested_init_block_size = 4 * kKiloByte,
-              .block_alloc = &std::malloc,
-              .block_dealloc = &std::free,
-              .logger_func = &default_logger_func,
-            };
-        }
-    };  // struct Options
+    // Arena hooked functions
+    // Hooks for adding external functionality.
+    // Init hook may return a pointer to a cookie to be stored in the arena.
+    // reset and destruction hooks will then be called with the same cookie =
+    // delete pointer. This allows us to save an external object per arena
+    // instance and use it on the other hooks (Note: It is just as legal for
+    // init to return NULL and not use the cookie feature). on_arena_reset and
+    // on_arena_destruction also receive the space used in the arena just before
+    // the reset.
+    void *(*on_arena_init)(Arena *arena,
+                           const std::source_location &loc){nullptr};
+    void (*on_arena_reset)(Arena *arena, void *cookie, uint64_t space_used,
+                           uint64_t space_wasted){nullptr};
+    void (*on_arena_allocation)(const type_info *alloc_type,
+                                uint64_t alloc_size, void *cookie){nullptr};
+    void (*on_arena_newblock)(uint64_t blk_num, uint64_t blk_size,
+                              void *cookie){nullptr};
+    void *(*on_arena_destruction)(Arena *arena, void *cookie,
+                                  uint64_t space_used,
+                                  uint64_t space_wasted){nullptr};
 
     /*
-     * Block struct of the memory block, it was always placement in a continuous memory area.
-     * Block has a header.
-     * and Arena's a Blocks' single linked-list
+     * A simplest function to get Options.
+     * just for testing or examples,
      */
-    class Block
-    {
-        struct Alignment
-        {
-            char* ptr;
-            uint64_t alignment_waste;
-        };
+    [[nodiscard, gnu::always_inline]] inline static auto GetDefaultOptions()
+        -> Options {
+      return {
+          .normal_block_size = 4 * kKiloByte,
+          .huge_block_size = 2 * kMegaByte,
+          .suggested_init_block_size = 4 * kKiloByte,
+          .block_alloc = &std::malloc,
+          .block_dealloc = &std::free,
+          .logger_func = &default_logger_func,
+      };
+    }
+  }; // struct Options
 
-       public:
-        Block(uint64_t size, Block* prev);
-
-        void Reset() noexcept;
-
-        // NOLINTNEXTLINE
-        [[gnu::always_inline]] inline auto Pos() noexcept -> char* { return reinterpret_cast<char*>(this) + _pos; }
-
-        static auto AlignPos(char* ptr, uint64_t alignment) noexcept -> Alignment;
-
-        // NOLINTNEXTLINE
-        [[gnu::always_inline]] inline auto CleanupPos() noexcept -> char* {
-            return reinterpret_cast<char*>(this) + _limit;  // NOLINT
-        }
-
-        /**
-         * @brief alloc the memory in the block.
-         * @notice alloc will not promise the Block has enough space for the alloc
-         * @param size, aligned to 8 in outter function.
-         * @param alignment
-         * @return char* as the new memory address.
-         */
-        auto alloc(uint64_t size, uint64_t alignment = kByteSize) noexcept -> char* {
-            Assert(has_enough_space(size, alignment),
-                   "Block::alloc should make sure has enough space to alloc");  // NOLINT
-            char* ptr = Pos();
-            auto [aligned_ptr, alignment_waste] = AlignPos(ptr, alignment);
-            _pos += (size + alignment_waste);
-            return aligned_ptr;
-        }
-
-        [[gnu::always_inline]] inline auto alloc_cleanup() noexcept -> char* {
-            Assert(_pos + kCleanupNodeSize <= _limit,
-                   "alloc_cleanup should make sure has enough space less rest space");  // NOLINT
-            _limit -= kCleanupNodeSize;
-            return CleanupPos();
-        }
-
-        [[gnu::always_inline]] inline void register_cleanup(void* obj, void (*cleanup)(void*)) noexcept {
-            auto* ptr = alloc_cleanup();
-            new (ptr) CleanupNode{obj, cleanup};
-        }
-
-        [[gnu::always_inline, nodiscard]] inline auto prev() const noexcept -> Block* { return _prev; }
-
-        [[gnu::always_inline, nodiscard]] inline auto size() const noexcept -> uint64_t { return _size; }
-
-        [[gnu::always_inline, nodiscard]] inline auto limit() const noexcept -> uint64_t { return _limit; }
-
-        [[gnu::always_inline, nodiscard]] inline auto pos() const noexcept -> uint64_t { return _pos; }
-
-        [[nodiscard, gnu::always_inline]] inline auto remain() const noexcept -> uint64_t {
-            Assert(_limit >= _pos, "remain should be ge than 0");  // NOLINT
-            return _limit - _pos;
-        }
-
-        [[nodiscard, gnu::always_inline]] inline auto has_enough_space(uint64_t size, uint64_t alignment) -> bool {
-            auto [_, alignment_waste] = AlignPos(Pos(), alignment);
-            // the size is no need to align, because the AlignPos has done the ptr alignment, and _limit is aligned
-            // to 16.
-            return _pos + alignment_waste + size <= _limit;
-        }
-
-        void run_cleanups() noexcept {
-            // NOLINTNEXTLINE
-            auto* node = reinterpret_cast<CleanupNode*>(reinterpret_cast<char*>(this) + _limit);
-            // NOLINTNEXTLINE
-            auto* last = reinterpret_cast<CleanupNode*>(reinterpret_cast<char*>(this) + _size);
-
-            // NOLINTNEXTLINE
-            for (; node < last; ++node) {
-                node->cleanup(node->element);
-            }
-        }
-
-        [[nodiscard, gnu::always_inline]] inline auto cleanups() const noexcept -> uint64_t {
-            uint64_t space = _size - _limit;
-            Assert(space % kCleanupNodeSize == 0, "cleanups space should aligned to sizeof (CleanupNode)");  // NOLINT
-            return space / kCleanupNodeSize;
-        }
-
-       private:
-        Block* _prev;
-        uint64_t _pos;
-        uint64_t _size;   // the size of the block
-        uint64_t _limit;  // the limit can be use for Create
+  /*
+   * Block struct of the memory block, it was always placement in a continuous
+   * memory area. Block has a header. and Arena's a Blocks' single linked-list
+   */
+  class Block {
+    struct Alignment {
+      char *ptr;
+      uint64_t alignment_waste;
     };
 
-    class memory_resource : public std::pmr::memory_resource
-    {
-       public:
-        explicit memory_resource(Arena* arena) : _arena(arena) {
-            Assert(arena != nullptr, "memory_resource should make sure arena is not nullptr");
-        };  // NOLINT
-        [[nodiscard]] auto get_arena() const -> Arena* { return _arena; }
+  public:
+    Block(uint64_t size, Block *prev);
 
-       protected:
-        auto do_allocate(size_t bytes, size_t alignment) noexcept -> void* override {
-            return reinterpret_cast<char*>(_arena->allocateAligned(bytes, std::max<uint64_t>(kByteSize, alignment)));
-        }
+    void Reset() noexcept;
 
-        void do_deallocate([[maybe_unused]] void* /*unused*/, [[maybe_unused]] size_t /*unused*/,
-                           [[maybe_unused]] size_t /*unused*/) noexcept override {};
-
-        [[nodiscard]] auto do_is_equal(const std::pmr::memory_resource& _other) const noexcept -> bool override {
-            try {
-                auto other = dynamic_cast<const memory_resource&>(_other);
-                return _arena == other._arena;
-            } catch (std::bad_cast&) {
-                return false;
-            }
-        }
-
-       private:
-        Arena* _arena;
-    };
-
-    /*
-     * Arena constructor copy version, copy the Options content to Arena
-     */
-    explicit Arena(const Options& ops) : _options(ops), _last_block(nullptr), _cookie(nullptr), _space_allocated(0ULL) {
-        init(std::source_location::current());
+    // NOLINTNEXTLINE
+    [[gnu::always_inline]] inline auto Pos() noexcept -> char * {
+      return reinterpret_cast<char *>(this) + _pos;
     }
 
-    /*
-     * Arena constructor move version, just support eXpire Options object.
-     */
-    explicit Arena(Options&& ops) noexcept
-        : _options(ops), _last_block(nullptr), _cookie(nullptr), _space_allocated(0ULL) {
-        init(std::source_location::current());
+    static auto AlignPos(char *ptr, uint64_t alignment) noexcept -> Alignment;
+
+    // NOLINTNEXTLINE
+    [[gnu::always_inline]] inline auto CleanupPos() noexcept -> char * {
+      return reinterpret_cast<char *>(this) + _limit; // NOLINT
     }
 
-    /*
-     * destructor of Arena will delete resource ptr.
-     * and free_all_blocks of the Arena.
+    /**
+     * @brief alloc the memory in the block.
+     * @notice alloc will not promise the Block has enough space for the alloc
+     * @param size, aligned to 8 in outter function.
+     * @param alignment
+     * @return char* as the new memory address.
      */
-    ~Arena() {
-        // free blocks
-        uint64_t all_waste_space = free_all_blocks();
-        // make sure the on_arena_destruction was not free.
-        if (_options.on_arena_destruction != nullptr) [[likely]] {
-            _options.on_arena_destruction(this, _cookie, _space_allocated, all_waste_space);
-        }
-        // free memory_resource first
-        delete _resource;
+    auto alloc(uint64_t size, uint64_t alignment = kByteSize) noexcept
+        -> char * {
+      Assert(
+          has_enough_space(size, alignment),
+          "Block::alloc should make sure has enough space to alloc"); // NOLINT
+      char *ptr = Pos();
+      auto [aligned_ptr, alignment_waste] = AlignPos(ptr, alignment);
+      _pos += (size + alignment_waste);
+      return aligned_ptr;
     }
 
-    /*
-     * Own function is used to control the memory and object outside of Arena.
-     * this function just register the destructor to the Arena, to make sure the Object owned
-     * has same life-cycle as the Arena object.
-     */
-    template <NonConstructable T>
-    [[gnu::noinline]] auto Own(T* obj) noexcept -> bool {
-        return addCleanup(obj, &arena_delete_object<T>);
+    [[gnu::always_inline]] inline auto alloc_cleanup() noexcept -> char * {
+      Assert(
+          _pos + kCleanupNodeSize <= _limit,
+          "alloc_cleanup should make sure has enough space less rest space"); // NOLINT
+      _limit -= kCleanupNodeSize;
+      return CleanupPos();
     }
 
-    /*
-     * Reset the Arena's internal status.
-     * it will free all blocks except the first.
-     * and reset all status of the Arena object.
-     * After Reset, Arena can be used as the new Arena Object.
-     */
-    inline auto Reset() noexcept -> uint64_t {
-        // free all blocks except the first block
-        uint64_t all_waste_space = free_blocks_except_head();
-        if (_options.on_arena_reset != nullptr) [[likely]] {
-            _options.on_arena_reset(this, _cookie, _space_allocated, all_waste_space);
-        }
-        // reset all internal status.
-        uint64_t reset_size = _space_allocated;
-        _space_allocated = _last_block->size();
-        _last_block->Reset();
-        return reset_size;
+    [[gnu::always_inline]] inline void
+    register_cleanup(void *obj, void (*cleanup)(void *)) noexcept {
+      auto *ptr = alloc_cleanup();
+      new (ptr) CleanupNode{obj, cleanup};
     }
 
-    /*
-     * SpaceAllocated() return the Arena totally owned memory.
-     */
-    [[nodiscard, gnu::always_inline]] inline auto SpaceAllocated() const noexcept -> uint64_t {
-        return _space_allocated;
+    [[gnu::always_inline, nodiscard]] inline auto prev() const noexcept
+        -> Block * {
+      return _prev;
     }
 
-    /*
-     * get remaining size of the last_block.
-     * caller can use is function to test whether the Arena will allocate a new block.
-     */
-    [[nodiscard, gnu::always_inline]] inline auto SpaceRemains() const noexcept -> uint64_t {
-        return _last_block->remain();
+    [[gnu::always_inline, nodiscard]] inline auto size() const noexcept
+        -> uint64_t {
+      return _size;
     }
 
-    /*
-     * Create by the Arena, and register cleanup function if needed
-     * always allocating in the arena memory
-     * the type T should is Creatable
-     */
-    template <Creatable T, typename... Args>
-    [[nodiscard]] auto Create(Args&&... args) noexcept -> T* {
-        char* ptr = allocateAligned(sizeof(T));
-        if (ptr != nullptr) [[likely]] {
-            Construct<T>(ptr, *this, std::forward<Args>(args)...);
-            T* result = reinterpret_cast<T*>(ptr);
-            if (!RegisterDestructor<T>(result)) [[unlikely]] {
-                return nullptr;
-            }
-            if (_options.on_arena_allocation != nullptr) [[likely]] {
-                _options.on_arena_allocation(&typeid(T), sizeof(T), _cookie);
-            }
-            return result;
-        }
+    [[gnu::always_inline, nodiscard]] inline auto limit() const noexcept
+        -> uint64_t {
+      return _limit;
+    }
+
+    [[gnu::always_inline, nodiscard]] inline auto pos() const noexcept
+        -> uint64_t {
+      return _pos;
+    }
+
+    [[nodiscard, gnu::always_inline]] inline auto remain() const noexcept
+        -> uint64_t {
+      Assert(_limit >= _pos, "remain should be ge than 0"); // NOLINT
+      return _limit - _pos;
+    }
+
+    [[nodiscard, gnu::always_inline]] inline auto
+    has_enough_space(uint64_t size, uint64_t alignment) -> bool {
+      auto [_, alignment_waste] = AlignPos(Pos(), alignment);
+      // the size is no need to align, because the AlignPos has done the ptr
+      // alignment, and _limit is aligned to 16.
+      return _pos + alignment_waste + size <= _limit;
+    }
+
+    void run_cleanups() noexcept {
+      // NOLINTNEXTLINE
+      auto *node = reinterpret_cast<CleanupNode *>(
+          reinterpret_cast<char *>(this) + _limit);
+      // NOLINTNEXTLINE
+      auto *last = reinterpret_cast<CleanupNode *>(
+          reinterpret_cast<char *>(this) + _size);
+
+      // NOLINTNEXTLINE
+      for (; node < last; ++node) {
+        node->cleanup(node->element);
+      }
+    }
+
+    [[nodiscard, gnu::always_inline]] inline auto cleanups() const noexcept
+        -> uint64_t {
+      uint64_t space = _size - _limit;
+      Assert(space % kCleanupNodeSize == 0,
+             "cleanups space should aligned to sizeof (CleanupNode)"); // NOLINT
+      return space / kCleanupNodeSize;
+    }
+
+  private:
+    Block *_prev;
+    uint64_t _pos;
+    uint64_t _size;  // the size of the block
+    uint64_t _limit; // the limit can be use for Create
+  };
+
+  class memory_resource : public std::pmr::memory_resource {
+  public:
+    explicit memory_resource(Arena *arena) : _arena(arena) {
+      Assert(arena != nullptr,
+             "memory_resource should make sure arena is not nullptr");
+    }; // NOLINT
+
+    // Allow updating arena pointer after move
+    void set_arena(Arena *arena) noexcept { _arena = arena; }
+    [[nodiscard]] auto get_arena() const -> Arena * { return _arena; }
+
+  protected:
+    auto do_allocate(size_t bytes, size_t alignment) noexcept
+        -> void * override {
+      return reinterpret_cast<char *>(_arena->allocateAligned(
+          bytes, std::max<uint64_t>(kByteSize, alignment)));
+    }
+
+    void do_deallocate([[maybe_unused]] void * /*unused*/,
+                       [[maybe_unused]] size_t /*unused*/,
+                       [[maybe_unused]] size_t /*unused*/) noexcept override {};
+
+    [[nodiscard]] auto
+    do_is_equal(const std::pmr::memory_resource &_other) const noexcept
+        -> bool override {
+      const auto *other = dynamic_cast<const memory_resource *>(&_other);
+      return other != nullptr && _arena == other->_arena;
+    }
+
+  private:
+    Arena *_arena;
+  };
+
+  /*
+   * Arena constructor copy version, copy the Options content to Arena
+   */
+  explicit Arena(const Options &ops)
+      : _options(ops), _last_block(nullptr), _cookie(nullptr),
+        _space_allocated(0ULL) {
+    init(std::source_location::current());
+  }
+
+  /*
+   * Arena constructor move version, just support eXpire Options object.
+   */
+  explicit Arena(Options &&ops) noexcept
+      : _options(ops), _last_block(nullptr), _cookie(nullptr),
+        _space_allocated(0ULL) {
+    init(std::source_location::current());
+  }
+
+  /*
+   * destructor of Arena will delete resource ptr.
+   * and free_all_blocks of the Arena.
+   */
+  ~Arena() {
+    // free blocks
+    uint64_t all_waste_space = free_all_blocks();
+    // make sure the on_arena_destruction was not free.
+    if (_options.on_arena_destruction != nullptr) [[unlikely]] {
+      _options.on_arena_destruction(this, _cookie, _space_allocated,
+                                    all_waste_space);
+    }
+    // free memory_resource first
+    delete _resource;
+  }
+
+  /*
+   * Own function is used to control the memory and object outside of Arena.
+   * this function just register the destructor to the Arena, to make sure the
+   * Object owned has same life-cycle as the Arena object.
+   */
+  template <NonConstructable T>
+  [[gnu::noinline]] auto Own(T *obj) noexcept -> bool {
+    return addCleanup(obj, &arena_delete_object<T>);
+  }
+
+  /*
+   * Reset the Arena's internal status.
+   * it will free all blocks except the first.
+   * and reset all status of the Arena object.
+   * After Reset, Arena can be used as the new Arena Object.
+   */
+  inline auto Reset() noexcept -> uint64_t {
+    // free all blocks except the first block
+    uint64_t all_waste_space = free_blocks_except_head();
+    if (_options.on_arena_reset != nullptr) [[unlikely]] {
+      _options.on_arena_reset(this, _cookie, _space_allocated, all_waste_space);
+    }
+    // reset all internal status.
+    uint64_t reset_size = _space_allocated;
+    _space_allocated = _last_block->size();
+    _last_block->Reset();
+    return reset_size;
+  }
+
+  /*
+   * SpaceAllocated() return the Arena totally owned memory.
+   */
+  [[nodiscard, gnu::always_inline]] inline auto SpaceAllocated() const noexcept
+      -> uint64_t {
+    return _space_allocated;
+  }
+
+  /*
+   * get remaining size of the last_block.
+   * caller can use is function to test whether the Arena will allocate a new
+   * block.
+   */
+  [[nodiscard, gnu::always_inline]] inline auto SpaceRemains() const noexcept
+      -> uint64_t {
+    return _last_block->remain();
+  }
+
+  /*
+   * Create by the Arena, and register cleanup function if needed
+   * always allocating in the arena memory
+   * the type T should is Creatable
+   */
+  template <Creatable T, typename... Args>
+  [[nodiscard]] auto Create(Args &&...args) noexcept -> T * {
+    char *ptr = allocateAligned(sizeof(T));
+    if (ptr != nullptr) [[likely]] {
+      Construct<T>(ptr, *this, std::forward<Args>(args)...);
+      T *result = reinterpret_cast<T *>(ptr);
+      if (!RegisterDestructor<T>(result)) [[unlikely]] {
         return nullptr;
+      }
+      if (_options.on_arena_allocation != nullptr) [[unlikely]] {
+        _options.on_arena_allocation(&typeid(T), sizeof(T), _cookie);
+      }
+      return result;
     }
+    return nullptr;
+  }
 
-    /*
-     * Create Array of Objects with num length.
-     * T should be Creatable, and TriviallyDestructible.
-     * because CreateArray do not RegisterDestructor.
-     */
-    template <Creatable T>
-    [[nodiscard]] auto CreateArray(uint64_t num) noexcept -> T*
-        requires TriviallyDestructible<T>
-    {
-        if (num > std::numeric_limits<uint64_t>::max() / sizeof(T)) {
-            auto output_message = fmt::format(
-              "CreateArray need too many memory, that more than max of uint64_t, the num of array is {}, and the Type "
-              "is {}, sizeof T is {}",
-              num, typeid(T).name(), sizeof(T));
-            _options.logger_func(output_message);
+  /*
+   * Create Array of Objects with num length.
+   * T should be Creatable, and TriviallyDestructible.
+   * because CreateArray do not RegisterDestructor.
+   */
+  template <Creatable T>
+  [[nodiscard]] auto CreateArray(uint64_t num) noexcept -> T *
+    requires TriviallyDestructible<T>
+  {
+    if (num > std::numeric_limits<uint64_t>::max() / sizeof(T)) {
+      auto output_message =
+          fmt::format("CreateArray need too many memory, that more than max of "
+                      "uint64_t, the num of array is {}, and the Type "
+                      "is {}, sizeof T is {}",
+                      num, typeid(T).name(), sizeof(T));
+      _options.logger_func(output_message);
+      return nullptr;
+    }
+    const uint64_t size = sizeof(T) * num;
+    char *ptr = allocateAligned(size);
+    if (ptr != nullptr) [[likely]] {
+      T *curr = reinterpret_cast<T *>(ptr);
+      for (uint64_t i = 0; i < num; ++i) {
+        Construct<T>(curr++, *this);
+      }
+      if (_options.on_arena_allocation != nullptr) [[unlikely]] {
+        _options.on_arena_allocation(&typeid(T), size, _cookie);
+      }
+      return reinterpret_cast<T *>(ptr);
+    }
+    return nullptr;
+  }
+
+  /*
+   * Allocate a piece of aligned memory in the arena.
+   * return nullptr means failure
+   * this function is used for replacement of std::malloc.
+   */
+  [[nodiscard]] auto AllocateAligned(uint64_t bytes,
+                                     uint64_t alignment = kByteSize) noexcept
+      -> char * {
+    if (char *ptr = allocateAligned(bytes, alignment); ptr != nullptr)
+        [[likely]] {
+      if (_options.on_arena_allocation != nullptr) [[unlikely]] {
+        _options.on_arena_allocation(nullptr, bytes, _cookie);
+      }
+      return ptr;
+    }
+    return nullptr;
+  }
+
+  /*
+   * Allocate a piece of aligned memory, and place a cleanup node in end of
+   * block. return nullptr means failure
+   */
+  [[nodiscard]] auto
+  AllocateAlignedAndAddCleanup(uint64_t bytes, void (*cleanup)(void *),
+                               void *element = nullptr) noexcept -> char * {
+    if (char *ptr = allocateAligned(bytes); ptr != nullptr) [[likely]] {
+      if (addCleanup(element == nullptr ? ptr : element, cleanup)) [[likely]] {
+        if (_options.on_arena_allocation != nullptr) [[unlikely]] {
+          _options.on_arena_allocation(nullptr, bytes, _cookie);
         }
-        const uint64_t size = sizeof(T) * num;
-        char* ptr = allocateAligned(size);
-        if (ptr != nullptr) [[likely]] {
-            T* curr = reinterpret_cast<T*>(ptr);
-            for (uint64_t i = 0; i < num; ++i) {
-                Construct<T>(curr++, *this);
-            }
-            if (_options.on_arena_allocation != nullptr) [[likely]] {
-                _options.on_arena_allocation(&typeid(T), size, _cookie);
-            }
-            return reinterpret_cast<T*>(ptr);
-        }
-        return nullptr;
+        return ptr;
+      }
     }
+    return nullptr;
+  }
 
-    /*
-     * Allocate a piece of aligned memory in the arena.
-     * return nullptr means failure
-     * this function is used for replacement of std::malloc.
-     */
-    [[nodiscard]] auto AllocateAligned(uint64_t bytes, uint64_t alignment = kByteSize) noexcept -> char* {
-        if (char* ptr = allocateAligned(bytes, alignment); ptr != nullptr) [[likely]] {
-            if (_options.on_arena_allocation != nullptr) [[likely]] {
-                _options.on_arena_allocation(nullptr, bytes, _cookie);
-            }
-            return ptr;
-        }
-        return nullptr;
+  [[gnu::always_inline]] inline auto get_memory_resource() noexcept
+      -> memory_resource * {
+    Assert(_resource != nullptr,
+           "memory_resource should make sure _resource is not nullptr, or "
+           "dereference crash"); // NOLINT
+    return _resource;
+  };
+
+  /*
+   * check the ptr whether be included by the Arena.
+   */
+  auto check(const char *ptr) -> ArenaContainStatus;
+
+  /*
+   * get all cleanup nodes, just for testing.
+   */
+  [[maybe_unused]] auto cleanups() -> uint64_t {
+    uint64_t total = 0;
+    Block *curr = _last_block;
+    while (curr != nullptr) {
+      total += curr->cleanups();
+      curr = curr->prev();
     }
+    return total;
+  }
 
-    /*
-     * Allocate a piece of aligned memory, and place a cleanup node in end of block.
-     * return nullptr means failure
-     */
-    [[nodiscard]] auto AllocateAlignedAndAddCleanup(uint64_t bytes, void (*cleanup)(void*),
-                                                    void* element = nullptr) noexcept -> char* {
-        if (char* ptr = allocateAligned(bytes); ptr != nullptr) [[likely]] {
-            if (addCleanup(element == nullptr ? ptr : element, cleanup)) [[likely]] {
-                if (_options.on_arena_allocation != nullptr) [[likely]] {
-                    {
-                        _options.on_arena_allocation(nullptr, bytes, _cookie);
-                    }
-                }
-                return ptr;
-            }
-        }
-        return nullptr;
+private:
+  /*
+   * init the arena
+   * call the callback to monitor and metrics: this arena was inited.
+   */
+  [[gnu::always_inline]] inline void
+  init(const std::source_location &loc) noexcept {
+    try {
+      _resource = new memory_resource{this};
+    } catch (std::bad_alloc &ex) {
+      _resource = nullptr;
+      _options.logger_func("new memory resource failed while Arena::init");
     }
-
-    [[gnu::always_inline]] inline auto get_memory_resource() noexcept -> memory_resource* {
-        Assert(_resource != nullptr,
-               "memory_resource should make sure _resource is not nullptr, or dereference crash");  // NOLINT
-        return _resource;
-    };
-
-    /*
-     * check the ptr whether be included by the Arena.
-     */
-    auto check(const char* ptr) -> ArenaContainStatus;
-
-    /*
-     * get all cleanup nodes, just for testing.
-     */
-    [[maybe_unused]] auto cleanups() -> uint64_t {
-        uint64_t total = 0;
-        Block* curr = _last_block;
-        while (curr != nullptr) {
-            total += curr->cleanups();
-            curr = curr->prev();
-        }
-        return total;
+    if (_options.on_arena_init != nullptr) [[unlikely]] {
+      _cookie = _options.on_arena_init(this, loc);
     }
+  }
 
-   private:
-    /*
-     * init the arena
-     * call the callback to monitor and metrics: this arena was inited.
-     */
-    [[gnu::always_inline]] inline void init(const std::source_location& loc) noexcept {
-        try {
-            _resource = new memory_resource{this};
-        } catch (std::bad_alloc& ex) {
-            _resource = nullptr;
-            _options.logger_func("new memory resource failed while Arena::init");
-        }
-        if (_options.on_arena_init != nullptr) [[likely]] {
-            _cookie = _options.on_arena_init(this, loc);
-        }
-    }
+  /*
+   * new a block within the arena.
+   * New Block while current Block has not enough memory.
+   */
+  auto newBlock(uint64_t min_bytes, Block *prev_block) noexcept -> Block *;
 
-    /*
-     * new a block within the arena.
-     * New Block while current Block has not enough memory.
-     */
-    auto newBlock(uint64_t min_bytes, Block* prev_block) noexcept -> Block*;
+  /*
+   * internal allocate aligned impl.
+   */
+  auto allocateAligned(uint64_t bytes, uint64_t alignment = kByteSize) noexcept
+      -> char *;
 
-    /*
-     * internal allocate aligned impl.
-     */
-    auto allocateAligned(uint64_t bytes, uint64_t alignment = kByteSize) noexcept -> char*;
-
-    /*
-     * check if needed a new block
-     */
-    [[nodiscard, gnu::always_inline]] inline auto need_create_new_block(uint64_t need_bytes,
-                                                                        uint64_t alignment) noexcept -> bool {
-        return (_last_block == nullptr) || not _last_block->has_enough_space(need_bytes, alignment);
-    }
-
-    /*
-     * add A Cleanup node to current block.
-     */
-    [[nodiscard]] auto addCleanup(void* obj, void (*cleanup)(void*)) noexcept -> bool {
-        if (need_create_new_block(kCleanupNodeSize, kByteSize)) [[unlikely]] {
-            Block* curr = newBlock(kCleanupNodeSize, _last_block);
-            if (curr != nullptr) {
-                _last_block = curr;
-            } else {
-                return false;
-            }
-        }
-        _last_block->register_cleanup(obj, cleanup);
-        return true;
-    }
-
-    /*
-     * a thin wrapper for AlignUpTo
-     */
-    [[nodiscard, gnu::always_inline]] static inline auto align_size(uint64_t n) noexcept -> uint64_t {
-        return AlignUpTo<kByteSize>(n);
-    }
-
-    template <typename T>
-    [[nodiscard, gnu::always_inline]] inline auto RegisterDestructor(T* ptr) noexcept -> bool {
-        return RegisterDestructorInternal(ptr, typename ArenaHelper<T>::is_destructor_skippable::type());
-    }
-
-    template <typename T>
-    [[nodiscard, gnu::always_inline]] inline auto RegisterDestructorInternal(T* /*unused*/,
-                                                                             ::std::true_type /*unused*/) noexcept
+  /*
+   * check if needed a new block
+   */
+  [[nodiscard, gnu::always_inline]] inline auto
+  need_create_new_block(uint64_t need_bytes, uint64_t alignment) noexcept
       -> bool {
-        return true;
-    }
+    return (_last_block == nullptr) ||
+           not _last_block->has_enough_space(need_bytes, alignment);
+  }
 
-    template <typename T>
-    [[nodiscard, gnu::always_inline]] inline auto RegisterDestructorInternal(T* ptr,
-                                                                             ::std::false_type /*unused*/) noexcept
+  /*
+   * add A Cleanup node to current block.
+   */
+  [[nodiscard]] auto addCleanup(void *obj, void (*cleanup)(void *)) noexcept
       -> bool {
-        return addCleanup(ptr, &arena_destruct_object<T>);
-    }
-
-    /*
-     * free all blocks and return all remains size of all blocks that was freed.
-     */
-    auto free_all_blocks() noexcept -> uint64_t {
-        Block* curr = _last_block;
-        Block* prev = nullptr;
-        uint64_t remain_size = 0;
-
-        while (curr != nullptr) {
-            prev = curr->prev();
-            // add the size of curr blk.
-            remain_size += curr->remain();
-            // run all cleanups first
-            curr->run_cleanups();
-            _options.block_dealloc(curr);
-            curr = prev;
-        }
-        _last_block = nullptr;
-        return remain_size;
-    }
-
-    /*
-     * free all blocks except the first block.
-     */
-    auto free_blocks_except_head() noexcept -> uint64_t {
-        Block* curr = _last_block;
-        Block* prev = nullptr;
-        uint64_t remain_size = 0;
-
-        while (curr != nullptr && curr->prev() != nullptr) {
-            prev = curr->prev();
-            // add the size of curr blk.
-            remain_size += curr->remain();
-            // run all cleanups first
-            curr->run_cleanups();
-            _options.block_dealloc(curr);
-            curr = prev;
-        }
-        Assert(curr != nullptr, "curr should not be nullptr");
-        // add the curr blk remain to result
-        remain_size += curr->remain();
-        // reset the last_block_ to the first block
+    if (need_create_new_block(kCleanupNodeSize, kByteSize)) [[unlikely]] {
+      Block *curr = newBlock(kCleanupNodeSize, _last_block);
+      if (curr != nullptr) {
         _last_block = curr;
-        return remain_size;
+      } else {
+        return false;
+      }
     }
+    _last_block->register_cleanup(obj, cleanup);
+    return true;
+  }
 
-    Options _options;
-    Block* _last_block;
-    memory_resource* _resource{nullptr};
+  /*
+   * a thin wrapper for AlignUpTo
+   */
+  [[nodiscard, gnu::always_inline]] static inline auto
+  align_size(uint64_t n) noexcept -> uint64_t {
+    return AlignUpTo<kByteSize>(n);
+  }
 
-    // should be initialized by on_arena_init
-    // and should be destroyed by on_arena_destruction
-    void* _cookie;
+  template <typename T>
+  [[nodiscard, gnu::always_inline]] inline auto
+  RegisterDestructor(T *ptr) noexcept -> bool {
+    return RegisterDestructorInternal(
+        ptr, typename ArenaHelper<T>::is_destructor_skippable::type());
+  }
 
-    uint64_t _space_allocated;
+  template <typename T>
+  [[nodiscard, gnu::always_inline]] inline auto
+  RegisterDestructorInternal(T * /*unused*/,
+                             ::std::true_type /*unused*/) noexcept -> bool {
+    return true;
+  }
 
-    static constexpr uint64_t kThresholdHuge = 4;
+  template <typename T>
+  [[nodiscard, gnu::always_inline]] inline auto
+  RegisterDestructorInternal(T *ptr, ::std::false_type /*unused*/) noexcept
+      -> bool {
+    return addCleanup(ptr, &arena_destruct_object<T>);
+  }
 
-    friend class ArenaTestHelper;
+  /*
+   * free all blocks and return all remains size of all blocks that was freed.
+   */
+  auto free_all_blocks() noexcept -> uint64_t {
+    Block *curr = _last_block;
+    Block *prev = nullptr;
+    uint64_t remain_size = 0;
 
-    /*
-     * because of using 'new placement' do not need to allocate memory
-     * so no bad_alloc will be thrown
-     */
-    template <typename T, typename... Args>
-    [[gnu::always_inline]] inline static auto Construct(void* ptr, Arena& arena, Args&&... args) noexcept -> T* {
-        // placement new make the new Object T is in the ptr-> memory.
-        if constexpr (std::is_constructible_v<T, Args..., std::pmr::polymorphic_allocator<T>>) {
-            return new (ptr) T(std::forward<Args>(args)..., arena.get_memory_resource());
-        } else if constexpr (std::is_constructible_v<T, Arena&, Args...>) {
-            return new (ptr) T(arena, std::forward<Args>(args)...);
-        } else {
-            return new (ptr) T(std::forward<Args>(args)...);
-        }
+    while (curr != nullptr) {
+      prev = curr->prev();
+      // add the size of curr blk.
+      remain_size += curr->remain();
+      // run all cleanups first
+      curr->run_cleanups();
+      _options.block_dealloc(curr);
+      curr = prev;
     }
+    _last_block = nullptr;
+    return remain_size;
+  }
 
-};  // class Arena
+  /*
+   * free all blocks except the first block.
+   */
+  auto free_blocks_except_head() noexcept -> uint64_t {
+    Block *curr = _last_block;
+    Block *prev = nullptr;
+    uint64_t remain_size = 0;
+
+    while (curr != nullptr && curr->prev() != nullptr) {
+      prev = curr->prev();
+      // add the size of curr blk.
+      remain_size += curr->remain();
+      // run all cleanups first
+      curr->run_cleanups();
+      _options.block_dealloc(curr);
+      curr = prev;
+    }
+    Assert(curr != nullptr, "curr should not be nullptr");
+    // add the curr blk remain to result
+    remain_size += curr->remain();
+    // reset the last_block_ to the first block
+    _last_block = curr;
+    return remain_size;
+  }
+
+  Options _options;
+  Block *_last_block;
+  memory_resource *_resource{nullptr};
+
+  // should be initialized by on_arena_init
+  // and should be destroyed by on_arena_destruction
+  void *_cookie;
+
+  uint64_t _space_allocated;
+
+  static constexpr uint64_t kThresholdHuge = 4;
+
+  friend class ArenaTestHelper;
+
+  /*
+   * because of using 'new placement' do not need to allocate memory
+   * so no bad_alloc will be thrown
+   */
+  template <typename T, typename... Args>
+  [[gnu::always_inline]] inline static auto Construct(void *ptr, Arena &arena,
+                                                      Args &&...args) noexcept
+      -> T * {
+    // placement new make the new Object T is in the ptr-> memory.
+    if constexpr (std::is_constructible_v<T, Args...,
+                                          std::pmr::polymorphic_allocator<T>>) {
+      return new (ptr)
+          T(std::forward<Args>(args)..., arena.get_memory_resource());
+    } else if constexpr (std::is_constructible_v<T, Arena &, Args...>) {
+      return new (ptr) T(arena, std::forward<Args>(args)...);
+    } else {
+      return new (ptr) T(std::forward<Args>(args)...);
+    }
+  }
+
+}; // class Arena
 
 // the size of the Block's header.
-static constexpr uint64_t kBlockHeaderSize = AlignUpTo<kByteSize>(static_cast<uint64_t>(sizeof(Arena::Block)));
+static constexpr uint64_t kBlockHeaderSize =
+    AlignUpTo<kByteSize>(static_cast<uint64_t>(sizeof(Arena::Block)));
 
-}  // namespace arena
+} // namespace arena

--- a/include/arena/arenahelper.hpp
+++ b/include/arena/arenahelper.hpp
@@ -18,48 +18,77 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <memory_resource>
 #include <type_traits>
 #include <utility>
-#include <memory_resource>
 
 // NOLINTBEGIN
 #include "arena/align.hpp"
-#define ArenaFullManagedTag using ArenaManaged_ = void;                    // NOLINT
-#define ArenaManagedCreateOnlyTag using ArenaManagedSkipDestruct_ = void;  // NOLINT
+#define ArenaFullManagedTag using ArenaManaged_ = void; // NOLINT
+#define ArenaManagedCreateOnlyTag                                              \
+  using ArenaManagedSkipDestruct_ = void; // NOLINT
 
 // NOLINTEND
 
 namespace arena {
+
+/*
+ * Detect if T is a PMR container with trivially destructible value_type.
+ * For such containers, we can skip destructor registration because:
+ * 1. Arena's deallocate() is a no-op
+ * 2. The elements don't need destruction
+ */
+template <typename T, typename = void>
+struct is_pmr_trivial_container : std::false_type {};
+
+template <typename T>
+struct is_pmr_trivial_container<
+    T,
+    std::void_t<typename T::allocator_type, typename T::value_type,
+                std::enable_if_t<
+                    std::is_same_v<typename T::allocator_type,
+                                   std::pmr::polymorphic_allocator<
+                                       typename T::value_type>> &&
+                    std::is_trivially_destructible_v<typename T::value_type>>>>
+    : std::true_type {};
+
 /*
  * class ArenaHelper is for helping the Type stored in the Arena memory.
  *
- * it uses type_traits and constexpr techniques to indicates supporting for arena for a type T at compiler time.
+ * it uses type_traits and constexpr techniques to indicates supporting for
+ * arena for a type T at compiler time.
  */
 class Arena;
 
-template <typename T>
-class ArenaHelper
-{
-   public:
-    template <typename U>
-    static auto DestructionSkippable(const typename U::ArenaManagedSkipDestruct_*) -> char;
+template <typename T> class ArenaHelper {
+public:
+  template <typename U>
+  static auto
+  DestructionSkippable(const typename U::ArenaManagedSkipDestruct_ *) -> char;
 
-    template <typename U>
-    static auto DestructionSkippable(...) -> double;
+  template <typename U> static auto DestructionSkippable(...) -> double;
 
-    using is_destructor_skippable =
-      std::integral_constant<bool, sizeof(DestructionSkippable<T>(static_cast<const T*>(0))) == sizeof(char) ||
-                                     std::is_trivially_destructible<T>::value>;
+  // Skip destructor registration if:
+  // 1. Has ArenaManagedSkipDestruct_ tag, OR
+  // 2. Is trivially destructible, OR
+  // 3. Is a PMR container with trivially destructible elements
+  using is_destructor_skippable =
+      std::integral_constant<bool,
+                             sizeof(DestructionSkippable<T>(
+                                 static_cast<const T *>(0))) == sizeof(char) ||
+                                 std::is_trivially_destructible<T>::value ||
+                                 is_pmr_trivial_container<T>::value>;
 
-    template <typename U>
-    static auto ArenaConstructable(const typename U::ArenaManaged_*) -> char;
-    template <typename U>
-    static auto ArenaConstructable(...) -> double;
+  template <typename U>
+  static auto ArenaConstructable(const typename U::ArenaManaged_ *) -> char;
+  template <typename U> static auto ArenaConstructable(...) -> double;
 
-    using is_arena_constructable =
-      std::integral_constant<bool, sizeof(ArenaConstructable<T>(static_cast<const T*>(0))) == sizeof(char)>;
+  using is_arena_constructable =
+      std::integral_constant<bool,
+                             sizeof(ArenaConstructable<T>(
+                                 static_cast<const T *>(0))) == sizeof(char)>;
 
-    friend class Arena;
+  friend class Arena;
 };
 
 /*
@@ -73,14 +102,13 @@ class ArenaHelper
  * necessary to see the underlying generated code traits.
  */
 template <typename T>
-struct is_arena_full_managable : ArenaHelper<T>::is_arena_constructable
-{};
+struct is_arena_full_managable : ArenaHelper<T>::is_arena_constructable {};
 template <typename T>
-struct is_destructor_skippable : ArenaHelper<T>::is_destructor_skippable
-{};
+struct is_destructor_skippable : ArenaHelper<T>::is_destructor_skippable {};
 
 template <typename T>
-concept Constructable = is_arena_full_managable<T>::value || is_destructor_skippable<T>::value;
+concept Constructable =
+    is_arena_full_managable<T>::value || is_destructor_skippable<T>::value;
 
 template <typename T>
 concept NonConstructable = !is_arena_full_managable<T>::value;
@@ -88,4 +116,4 @@ concept NonConstructable = !is_arena_full_managable<T>::value;
 template <typename T>
 concept DestructorSkippable = is_destructor_skippable<T>::value;
 
-}  // namespace arena
+} // namespace arena

--- a/src/arena.cc
+++ b/src/arena.cc
@@ -25,136 +25,150 @@ namespace arena {
  * the Block's constructor,
  * and it should link to the prev Block;
  */
-Arena::Block::Block(uint64_t size, Block* prev) : _prev(prev), _pos(kBlockHeaderSize), _size(size), _limit(size) {}
+Arena::Block::Block(uint64_t size, Block *prev)
+    : _prev(prev), _pos(kBlockHeaderSize), _size(size), _limit(size) {}
 
-auto Arena::Block::AlignPos(char* ptr, uint64_t alignment) noexcept -> Arena::Block::Alignment {
-    Assert(alignment >= kByteSize, "AlignPos need alignment >= 8");     // NOLINT
-    Assert(alignment <= kInt256Size, "AlignPos need alignment <= 32");  // NOLINT
-    // if aligment == 9, this function is useless, but if is expensive, just do the calculation below.
-    auto ptr_as_int = reinterpret_cast<uint64_t>(ptr);
-    auto reminder = ptr_as_int % alignment;
-    // auto forward = (reminder == 0) ? 0 : (alignment - reminder);
-    // remove if in below code
-    auto forward = alignment * uint64_t(bool(reminder)) - reminder;
-    return {ptr + forward, forward};  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+auto Arena::Block::AlignPos(char *ptr, uint64_t alignment) noexcept
+    -> Arena::Block::Alignment {
+  Assert(alignment >= kByteSize, "AlignPos need alignment >= 8");    // NOLINT
+  Assert(alignment <= kInt256Size, "AlignPos need alignment <= 32"); // NOLINT
+  // if aligment == 9, this function is useless, but if is expensive, just do
+  // the calculation below.
+  auto ptr_as_int = reinterpret_cast<uint64_t>(ptr);
+  auto reminder = ptr_as_int % alignment;
+  // auto forward = (reminder == 0) ? 0 : (alignment - reminder);
+  // remove if in below code
+  auto forward = alignment * uint64_t(bool(reminder)) - reminder;
+  return {ptr + forward,
+          forward}; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 /*
  * will generate a new Block with a good size.
  */
-auto Arena::newBlock(uint64_t min_bytes, Block* prev_block) noexcept -> Arena::Block* {
-    uint64_t required_bytes = min_bytes + kBlockHeaderSize;
-    uint64_t size = 0;
+auto Arena::newBlock(uint64_t min_bytes, Block *prev_block) noexcept
+    -> Arena::Block * {
+  uint64_t required_bytes = min_bytes + kBlockHeaderSize;
+  uint64_t size = 0;
 
-    if (min_bytes > std::numeric_limits<uint64_t>::max() - kBlockHeaderSize) {
-        auto output_message = fmt::format(
-          "newBlock need too many min_bytes : {}, it add kBlockHeaderSize more than uint64_t max.", min_bytes);
-        _options.logger_func(output_message);
+  if (min_bytes > std::numeric_limits<uint64_t>::max() - kBlockHeaderSize) {
+    auto output_message =
+        fmt::format("newBlock need too many min_bytes : {}, it add "
+                    "kBlockHeaderSize more than uint64_t max.",
+                    min_bytes);
+    _options.logger_func(output_message);
+    return nullptr;
+  }
+
+  // it was not called in the Arena's first chance.
+  if (prev_block != nullptr) [[likely]] {
+    // not the first block "New" action.
+    if (required_bytes <= _options.normal_block_size) {
+      size = _options.normal_block_size;
+    } else if (required_bytes <= _options.huge_block_size / kThresholdHuge) {
+      size = align::AlignUp(min_bytes, _options.normal_block_size);
+    } else if ((required_bytes > _options.huge_block_size / kThresholdHuge) &&
+               (required_bytes <= _options.huge_block_size)) {
+      size = _options.huge_block_size;
+    }
+    // for the more than huge_block_size size
+    // will be handle out of the code scope
+    // by now, the size remains to be 0.
+  } else {
+    // the size may be insufficient than the required.
+    size = _options.suggested_init_block_size;
+  }
+
+  // NOTICE: when the size will be change to required_bytes?
+  // #1. larger than huge on second or older block.
+  // #2. larger than suggested_init_block_size on first block.
+  // on both of them, the block will be monopolized.
+  //
+  // if size is insufficient, make it sufficient
+  size = std::max(size, required_bytes);
+
+  // allocate the memory by the block_alloc function.
+  // no AlignUpTo8 need, because
+  // normal_block_size and huge_block_size should be power of 2.
+  // if the size over the huge_block_size, the block will be monopolized.
+  void *mem = _options.block_alloc(size);
+  // if mem == nullptr, means no memory available for current os status,
+  // the placement new will trigger a segment-fault
+  if (mem == nullptr) [[unlikely]] {
+    return nullptr;
+  }
+
+  // call the on_arena_newblock callback
+  // if on_arena_newblock is nullptr, block num counting is a useless process,
+  // so avoid it.
+  if (_options.on_arena_newblock != nullptr) {
+    // count the blk num
+    uint64_t blk_num = 0;
+    for (Block *prev = prev_block; prev != nullptr;
+         prev = prev->prev(), ++blk_num) {
     }
 
-    // it was not called in the Arena's first chance.
-    if (prev_block != nullptr) [[likely]] {
-        // not the first block "New" action.
-        if (required_bytes <= _options.normal_block_size) {
-            size = _options.normal_block_size;
-        } else if (required_bytes <= _options.huge_block_size / kThresholdHuge) {
-            size = align::AlignUp(min_bytes, _options.normal_block_size);
-        } else if ((required_bytes > _options.huge_block_size / kThresholdHuge) &&
-                   (required_bytes <= _options.huge_block_size)) {
-            size = _options.huge_block_size;
-        }
-        // for the more than huge_block_size size
-        // will be handle out of the code scope
-        // by now, the size remains to be 0.
-    } else {
-        // the size may be insufficient than the required.
-        size = _options.suggested_init_block_size;
-    }
+    _options.on_arena_newblock(blk_num, size, _cookie);
+  }
 
-    // NOTICE: when the size will be change to required_bytes?
-    // #1. larger than huge on second or older block.
-    // #2. larger than suggested_init_block_size on first block.
-    // on both of them, the block will be monopolized.
-    //
-    // if size is insufficient, make it sufficient
-    size = std::max(size, required_bytes);
-
-    // allocate the memory by the block_alloc function.
-    // no AlignUpTo8 need, because
-    // normal_block_size and huge_block_size should be power of 2.
-    // if the size over the huge_block_size, the block will be monopolized.
-    void* mem = _options.block_alloc(size);
-    // if mem == nullptr, means no memory available for current os status,
-    // the placement new will trigger a segment-fault
-    if (mem == nullptr) [[unlikely]] {
-        return nullptr;
-    }
-
-    // call the on_arena_newblock callback
-    // if on_arena_newblock is nullptr, block num counting is a useless process, so avoid it.
-    if (_options.on_arena_newblock != nullptr) {
-        // count the blk num
-        uint64_t blk_num = 0;
-        for (Block* prev = prev_block; prev != nullptr; prev = prev->prev(), ++blk_num) {
-        }
-
-        _options.on_arena_newblock(blk_num, size, _cookie);
-    }
-
-    auto* blk = new (mem) Block(size, prev_block);
-    _space_allocated += size;
-    return blk;
+  auto *blk = new (mem) Block(size, prev_block);
+  _space_allocated += size;
+  return blk;
 }
 
 /*
  * Reset the status of Arena.
  */
 void Arena::Block::Reset() noexcept {
-    // run all cleanups first
-    run_cleanups();
-    _pos = kBlockHeaderSize;
-    _limit = _size;
+  // run all cleanups first
+  run_cleanups();
+  _pos = kBlockHeaderSize;
+  _limit = _size;
 }
 
 /*
  * allocate a piece of memory that aligned.
  * if return nullptr means failure
  */
-auto Arena::allocateAligned(uint64_t bytes, uint64_t alignment) noexcept -> char* {
-    uint64_t needed = align_size(bytes);
-    if (need_create_new_block(needed, alignment)) [[unlikely]] {
-        Block* curr = newBlock(needed, _last_block);
-        if (curr != nullptr) [[likely]] {
-            _last_block = curr;
-        } else {
-            return nullptr;
-        }
+auto Arena::allocateAligned(uint64_t bytes, uint64_t alignment) noexcept
+    -> char * {
+  uint64_t needed = align_size(bytes);
+  if (need_create_new_block(needed, alignment)) [[unlikely]] {
+    Block *curr = newBlock(needed, _last_block);
+    if (curr != nullptr) [[likely]] {
+      _last_block = curr;
+    } else {
+      return nullptr;
     }
-    char* result = _last_block->alloc(needed, alignment);
-    // re make sure aligned in debug model
-    Assert((reinterpret_cast<uint64_t>(result) & kByteSizeMask) == 0,
-           "alloc result should aligned kByteSize");  // NOLINT
-    return result;
+  }
+  char *result = _last_block->alloc(needed, alignment);
+  // re make sure aligned in debug model
+  Assert((reinterpret_cast<uint64_t>(result) & kByteSizeMask) == 0,
+         "alloc result should aligned kByteSize"); // NOLINT
+  return result;
 }
 
-auto Arena::check(const char* ptr) -> ArenaContainStatus {
-    auto* block = _last_block;
-    while (block != nullptr) {
-        int64_t offset = ptr - reinterpret_cast<char*>(block);
-        if (offset >= 0 && offset < static_cast<int64_t>(kBlockHeaderSize)) {
-            return ArenaContainStatus::BlockHeader;
-        }
-        if (offset >= static_cast<int64_t>(kBlockHeaderSize) && offset < static_cast<int64_t>(block->pos())) {
-            return ArenaContainStatus::BlockUsed;
-        }
-        if (offset >= static_cast<int64_t>(block->pos()) && offset < static_cast<int64_t>(block->limit())) {
-            return ArenaContainStatus::BlockUnUsed;
-        }
-        if (offset >= static_cast<int64_t>(block->limit()) && offset < static_cast<int64_t>(block->size())) {
-            return ArenaContainStatus::BlockCleanup;
-        }
-        block = block->prev();
+auto Arena::check(const char *ptr) -> ArenaContainStatus {
+  auto *block = _last_block;
+  while (block != nullptr) {
+    int64_t offset = ptr - reinterpret_cast<char *>(block);
+    if (offset >= 0 && offset < static_cast<int64_t>(kBlockHeaderSize)) {
+      return ArenaContainStatus::BlockHeader;
     }
-    return ArenaContainStatus::NotContain;
+    if (offset >= static_cast<int64_t>(kBlockHeaderSize) &&
+        offset < static_cast<int64_t>(block->pos())) {
+      return ArenaContainStatus::BlockUsed;
+    }
+    if (offset >= static_cast<int64_t>(block->pos()) &&
+        offset < static_cast<int64_t>(block->limit())) {
+      return ArenaContainStatus::BlockUnUsed;
+    }
+    if (offset >= static_cast<int64_t>(block->limit()) &&
+        offset < static_cast<int64_t>(block->size())) {
+      return ArenaContainStatus::BlockCleanup;
+    }
+    block = block->prev();
+  }
+  return ArenaContainStatus::NotContain;
 }
 
-}  // namespace arena
+} // namespace arena


### PR DESCRIPTION
## Summary

- Fix overflow detection in `newBlock()` and `CreateArray()` - was logging but not returning nullptr
- Fix move constructor bug where `resource->_arena` pointed to old Arena after move (dangling pointer)
- Fix `do_is_equal()` using try-catch with dynamic_cast reference, now uses pointer version
- Skip destructor registration for PMR containers with trivially destructible elements
- Fix `[[likely]]` annotations on hook callbacks (defaults are nullptr, should be `[[unlikely]]`)
- Add nanobench-based benchmark suite

## Test plan

- [x] All 54 existing tests pass
- [x] Verified move constructor fix with manual test
- [x] Verified PMR container optimization (no cleanup registration for `pmr::string`, `pmr::vector<int>`)
- [x] Benchmark runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)