### PR TITLE
Fix: skip fmt build when FBEC_MODULE is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ include_directories(fmt/include)
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(bench)
-if(NOT TARGET fmt::fmt)
+
+# When building as FBEC_MODULE, skip fmt build - parent project provides it
+if(NOT FBEC_MODULE AND NOT TARGET fmt::fmt)
     add_subdirectory(fmt)
 endif()


### PR DESCRIPTION
## Summary
- Skip building fmt subdirectory when `FBEC_MODULE` cmake variable is set
- Prevents duplicate symbol errors when parent project provides fmt library
- Maintains backward compatibility for standalone Arena builds

## Background
When Arena is built as part of FBE module (`FBEC_MODULE=1`), the parent project (ClapDB) provides the fmt library through seastar. Building fmt again in Arena causes duplicate symbol errors like:

```
duplicate symbol: fmt::v11::assert_fail defined in both 
  tools/FBE/modules/arena/fmt/libfmt.a and stdb-deps/lib64/libfmt.a
```

## Test plan
- [x] Standalone Arena build still works (no FBEC_MODULE set)
- [x] ClapDB build with FBEC_MODULE=1 no longer has duplicate symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)