### PR TITLE
feat: refactor error handling to std::expected with monadic operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Arena
     VERSION 1.0.0
-    DESCRIPTION "A C++20 memory allocation library inspired by the Chromium project"
+    DESCRIPTION "A C++23 memory allocation library inspired by the Chromium project"
     LANGUAGES CXX
 )
 
-# Set C++20 standard
-set(CMAKE_CXX_STANDARD 20)
+# Set C++23 standard (required for std::expected)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/bench/arena_bench.cc
+++ b/bench/arena_bench.cc
@@ -60,7 +60,7 @@ int main() {
 
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena::AllocateAligned", [&]() {
-      void *p = arena.AllocateAligned(32);
+      auto p = arena.AllocateAligned(32).value();
       nb::doNotOptimizeAway(p);
     });
 
@@ -86,7 +86,7 @@ int main() {
 
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena::AllocateAligned", [&]() {
-      void *p = arena.AllocateAligned(512);
+      auto p = arena.AllocateAligned(512).value();
       nb::doNotOptimizeAway(p);
     });
 
@@ -112,7 +112,7 @@ int main() {
     opts.huge_block_size = 64 * 1024 * 1024;
     Arena arena(opts);
     bench.run("Arena::AllocateAligned", [&]() {
-      void *p = arena.AllocateAligned(4096);
+      auto p = arena.AllocateAligned(4096).value();
       nb::doNotOptimizeAway(p);
     });
 
@@ -139,7 +139,7 @@ int main() {
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena + Reset", [&]() {
       for (int i = 0; i < 1000; ++i) {
-        void *p = arena.AllocateAligned(64);
+        auto p = arena.AllocateAligned(64).value();
         nb::doNotOptimizeAway(p);
       }
       arena.Reset();
@@ -169,7 +169,7 @@ int main() {
 
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena::Create<T>", [&]() {
-      auto *p = arena.Create<TestObject>();
+      auto p = arena.Create<TestObject>().value();
       nb::doNotOptimizeAway(p);
     });
 
@@ -195,7 +195,7 @@ int main() {
 
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena::Create<T>", [&]() {
-      auto *p = arena.Create<SimpleObject>();
+      auto p = arena.Create<SimpleObject>().value();
       nb::doNotOptimizeAway(p);
     });
 
@@ -255,8 +255,8 @@ int main() {
     Arena arena(Arena::Options::GetDefaultOptions());
     size_t idx = 0;
     bench.run("Arena::AllocateAligned", [&]() {
-      void *p =
-          arena.AllocateAligned(random_sizes[idx++ % random_sizes.size()]);
+      auto p = arena.AllocateAligned(random_sizes[idx++ % random_sizes.size()])
+                   .value();
       nb::doNotOptimizeAway(p);
     });
 
@@ -281,7 +281,7 @@ int main() {
 
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena + touch", [&]() {
-      char *p = arena.AllocateAligned(64);
+      char *p = arena.AllocateAligned(64).value();
       for (int i = 0; i < 64; i += 8) {
         p[i] = static_cast<char>(i);
       }
@@ -316,7 +316,7 @@ int main() {
     Arena arena(Arena::Options::GetDefaultOptions());
     bench.run("Arena + Reset", [&]() {
       for (int i = 0; i < 100; ++i) {
-        void *p = arena.AllocateAligned(pattern[i % pattern.size()]);
+        auto p = arena.AllocateAligned(pattern[i % pattern.size()]).value();
         nb::doNotOptimizeAway(p);
       }
       arena.Reset();

--- a/tests/arena_test.cc
+++ b/tests/arena_test.cc
@@ -16,17 +16,17 @@
 
 #include "arena/arena.hpp"
 
-#include <cstdint>   // for uint64_t
-#include <cstdlib>   // for free, malloc
-#include <cstring>   // for memcmp, strcmp
-#include <memory>    // for allocator, make_unique, unique_ptr
-#include <memory_resource>  // for pmr types
-#include <string>    // for string, operator==, basic_string
-#include <typeinfo>  // for type_info
-#include <vector>    // for vector, vector<>::allocator_type
+#include <cstdint>         // for uint64_t
+#include <cstdlib>         // for free, malloc
+#include <cstring>         // for memcmp, strcmp
+#include <memory>          // for allocator, make_unique, unique_ptr
+#include <memory_resource> // for pmr types
+#include <string>          // for string, operator==, basic_string
+#include <typeinfo>        // for type_info
+#include <vector>          // for vector, vector<>::allocator_type
 
-#include "arena/arenahelper.hpp"  // for ArenaFullManagedTag, ArenaManagedCr...
-#include "doctest/doctest.h"      // for binary_assert, CHECK_EQ, TestCase
+#include "arena/arenahelper.hpp" // for ArenaFullManagedTag, ArenaManagedCr...
+#include "doctest/doctest.h"     // for binary_assert, CHECK_EQ, TestCase
 
 #ifdef __amd64__
 #include <immintrin.h>
@@ -36,1319 +36,1425 @@ using arena::align::AlignUp;
 using arena::align::AlignUpTo;
 namespace pmr = std::pmr;
 namespace arena {
-class alloc_class
-{
-   public:
-    alloc_class() : init(static_cast<char*>(malloc(4 * 1024 * 1024))), curr(init) {}
-    virtual ~alloc_class() { free(init); }
+class alloc_class {
+public:
+  alloc_class()
+      : init(static_cast<char *>(malloc(4 * 1024 * 1024))), curr(init) {}
+  virtual ~alloc_class() { free(init); }
 
-    virtual auto alloc(uint64_t size) -> void* {
-        alloc_sizes.push_back(size);
-        void* ret = static_cast<void*>(curr);
-        ptrs.push_back(ret);
-        curr += size;
-        return ret;
-    }
+  virtual auto alloc(uint64_t size) -> void * {
+    alloc_sizes.push_back(size);
+    void *ret = static_cast<void *>(curr);
+    ptrs.push_back(ret);
+    curr += size;
+    return ret;
+  }
 
-    void dealloc(void* ptr) { free_ptrs.push_back(ptr); }
+  void dealloc(void *ptr) { free_ptrs.push_back(ptr); }
 
-    void reset() {
-        alloc_sizes.clear();
-        ptrs.clear();
-        free_ptrs.clear();
-    }
+  void reset() {
+    alloc_sizes.clear();
+    ptrs.clear();
+    free_ptrs.clear();
+  }
 
-    // private:
-    std::vector<uint64_t> alloc_sizes{};
-    std::vector<void*> ptrs{};
-    std::vector<void*> free_ptrs{};
-    char* init{nullptr};
-    char* curr{nullptr};
+  // private:
+  std::vector<uint64_t> alloc_sizes{};
+  std::vector<void *> ptrs{};
+  std::vector<void *> free_ptrs{};
+  char *init{nullptr};
+  char *curr{nullptr};
 };
 
-class alloc_fail_class : public alloc_class
-{
-   public:
-    auto alloc(uint64_t /*size*/) -> void* override { return nullptr; }
-    ~alloc_fail_class() override = default;
+class alloc_fail_class : public alloc_class {
+public:
+  auto alloc(uint64_t /*size*/) -> void * override { return nullptr; }
+  ~alloc_fail_class() override = default;
 };
 
-class BlockTest
-{
-   public:
-    BlockTest() : ptr(malloc(1024)) {}
-    ~BlockTest() { free(ptr); }
+class BlockTest {
+public:
+  BlockTest() : ptr(malloc(1024)) {}
+  ~BlockTest() { free(ptr); }
 
-   protected:
-    auto Pointer() -> void* { return ptr; }
+protected:
+  auto Pointer() -> void * { return ptr; }
 
-   private:
-    void* ptr{nullptr};
+private:
+  void *ptr{nullptr};
 };
 
-class cleanup_mock
-{
-   public:
-    void cleanup1(void* /*unused*/) { clean1 = true; }
-    void cleanup2(void* /*unused*/) { clean2 = true; }
-    void cleanup3(void* /*unused*/) { clean3 = true; }
-    bool clean1{false};
-    bool clean2{false};
-    bool clean3{false};
+class cleanup_mock {
+public:
+  void cleanup1(void * /*unused*/) { clean1 = true; }
+  void cleanup2(void * /*unused*/) { clean2 = true; }
+  void cleanup3(void * /*unused*/) { clean3 = true; }
+  bool clean1{false};
+  bool clean2{false};
+  bool clean3{false};
 };
 
-void cleanup_mock_fn1(void* p) { reinterpret_cast<cleanup_mock*>(p)->cleanup1(p); }
+void cleanup_mock_fn1(void *p) {
+  reinterpret_cast<cleanup_mock *>(p)->cleanup1(p);
+}
 
-void cleanup_mock_fn2(void* p) { reinterpret_cast<cleanup_mock*>(p)->cleanup2(p); }
+void cleanup_mock_fn2(void *p) {
+  reinterpret_cast<cleanup_mock *>(p)->cleanup2(p);
+}
 
-void cleanup_mock_fn3(void* p) { reinterpret_cast<cleanup_mock*>(p)->cleanup3(p); }
+void cleanup_mock_fn3(void *p) {
+  reinterpret_cast<cleanup_mock *>(p)->cleanup3(p);
+}
 
-thread_local cleanup_mock* mock_cleaners;
+thread_local cleanup_mock *mock_cleaners;
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.CotrTest1") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    CHECK_EQ(b->Pos(), reinterpret_cast<char*>(Pointer()) + kBlockHeaderSize);
-    CHECK_EQ(b->size(), 1024ULL);
-    CHECK_EQ(b->pos(), kBlockHeaderSize);
-    CHECK_EQ(b->limit(), 1024ULL);
-    CHECK_EQ(b->prev(), nullptr);
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  CHECK_EQ(b->Pos(), reinterpret_cast<char *>(Pointer()) + kBlockHeaderSize);
+  CHECK_EQ(b->size(), 1024ULL);
+  CHECK_EQ(b->pos(), kBlockHeaderSize);
+  CHECK_EQ(b->limit(), 1024ULL);
+  CHECK_EQ(b->prev(), nullptr);
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.CotrTest2") {
-    // NOLINTNEXTLINE
-    void* last = malloc(100);
-    auto* last_b = reinterpret_cast<Arena::Block*>(last);
-    auto* b = new (Pointer()) Arena::Block(1024, last_b);
-    CHECK_EQ(b->prev(), last_b);
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
-    // NOLINTNEXTLINE
-    free(last);
+  // NOLINTNEXTLINE
+  void *last = malloc(100);
+  auto *last_b = reinterpret_cast<Arena::Block *>(last);
+  auto *b = new (Pointer()) Arena::Block(1024, last_b);
+  CHECK_EQ(b->prev(), last_b);
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
+  // NOLINTNEXTLINE
+  free(last);
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.AllocTest") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    char* x = b->alloc(200);
-    CHECK_NE(x, nullptr);
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - 200ULL);
-    CHECK_EQ(b->Pos() - x, 200LL);
-    CHECK_EQ(b->pos(), kBlockHeaderSize + 200LL);
-    CHECK_EQ(b->size(), 1024ULL);
-    CHECK_EQ(b->limit(), 1024ULL);
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  char *x = b->alloc(200);
+  CHECK_NE(x, nullptr);
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - 200ULL);
+  CHECK_EQ(b->Pos() - x, 200LL);
+  CHECK_EQ(b->pos(), kBlockHeaderSize + 200LL);
+  CHECK_EQ(b->size(), 1024ULL);
+  CHECK_EQ(b->limit(), 1024ULL);
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.AllocCleanupTest") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    char* x = b->alloc_cleanup();
-    CHECK_NE(x, nullptr);
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - kCleanupNodeSize);
-    CHECK_EQ(b->limit(), b->size() - kCleanupNodeSize);
-    char* x1 = b->alloc_cleanup();
-    CHECK_EQ(x - x1, kCleanupNodeSize);
-    CHECK_EQ(b->limit(), b->size() - 2 * kCleanupNodeSize);
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  char *x = b->alloc_cleanup();
+  CHECK_NE(x, nullptr);
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - kCleanupNodeSize);
+  CHECK_EQ(b->limit(), b->size() - kCleanupNodeSize);
+  char *x1 = b->alloc_cleanup();
+  CHECK_EQ(x - x1, kCleanupNodeSize);
+  CHECK_EQ(b->limit(), b->size() - 2 * kCleanupNodeSize);
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.RegCleanupTest") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    mock_cleaners = new cleanup_mock;
-    b->register_cleanup(mock_cleaners, &cleanup_mock_fn1);
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - kCleanupNodeSize);
-    CHECK_EQ(b->limit(), b->size() - kCleanupNodeSize);
-    b->run_cleanups();
-    CHECK(mock_cleaners->clean1);
-    delete mock_cleaners;
-    mock_cleaners = nullptr;
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  mock_cleaners = new cleanup_mock;
+  b->register_cleanup(mock_cleaners, &cleanup_mock_fn1);
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - kCleanupNodeSize);
+  CHECK_EQ(b->limit(), b->size() - kCleanupNodeSize);
+  b->run_cleanups();
+  CHECK(mock_cleaners->clean1);
+  delete mock_cleaners;
+  mock_cleaners = nullptr;
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.RunCleanupTest") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    mock_cleaners = new cleanup_mock;
-    b->register_cleanup(mock_cleaners, &cleanup_mock_fn1);
-    b->register_cleanup(mock_cleaners, &cleanup_mock_fn2);
-    b->run_cleanups();
-    CHECK(mock_cleaners->clean1);
-    CHECK(mock_cleaners->clean2);
-    delete mock_cleaners;
-    mock_cleaners = nullptr;
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  mock_cleaners = new cleanup_mock;
+  b->register_cleanup(mock_cleaners, &cleanup_mock_fn1);
+  b->register_cleanup(mock_cleaners, &cleanup_mock_fn2);
+  b->run_cleanups();
+  CHECK(mock_cleaners->clean1);
+  CHECK(mock_cleaners->clean2);
+  delete mock_cleaners;
+  mock_cleaners = nullptr;
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.ResetTest") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    char* x = b->alloc(200);
-    CHECK_NE(x, nullptr);
-    CHECK_EQ(b->size(), 1024ULL);
-    CHECK_EQ(b->limit(), 1024ULL);
-    CHECK_EQ(b->remain(), 1024ULL - 200ULL - kBlockHeaderSize);
-    CHECK_EQ(b->Pos() - x, 200LL);
-    b->Reset();
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
-    CHECK_EQ(b->limit(), 1024ULL);
-    CHECK_EQ(b->Pos() - x, 0LL);
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  char *x = b->alloc(200);
+  CHECK_NE(x, nullptr);
+  CHECK_EQ(b->size(), 1024ULL);
+  CHECK_EQ(b->limit(), 1024ULL);
+  CHECK_EQ(b->remain(), 1024ULL - 200ULL - kBlockHeaderSize);
+  CHECK_EQ(b->Pos() - x, 200LL);
+  b->Reset();
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
+  CHECK_EQ(b->limit(), 1024ULL);
+  CHECK_EQ(b->Pos() - x, 0LL);
 }
 
 TEST_CASE_FIXTURE(BlockTest, "BlockTest.ResetwithCleanupTest") {
-    auto* b = new (Pointer()) Arena::Block(1024, nullptr);
-    mock_cleaners = new cleanup_mock;
-    char* x = b->alloc(200);
-    CHECK_NE(x, nullptr);
-    CHECK_EQ(b->remain(), 1024ULL - 200ULL - kBlockHeaderSize);
-    CHECK_EQ(b->Pos() - x, 200LL);
-    CHECK_EQ(b->limit(), 1024ULL);
+  auto *b = new (Pointer()) Arena::Block(1024, nullptr);
+  mock_cleaners = new cleanup_mock;
+  char *x = b->alloc(200);
+  CHECK_NE(x, nullptr);
+  CHECK_EQ(b->remain(), 1024ULL - 200ULL - kBlockHeaderSize);
+  CHECK_EQ(b->Pos() - x, 200LL);
+  CHECK_EQ(b->limit(), 1024ULL);
 
-    b->register_cleanup(mock_cleaners, &cleanup_mock_fn1);
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - kCleanupNodeSize - 200);
-    CHECK_EQ(b->limit(), 1024ULL - kCleanupNodeSize);
+  b->register_cleanup(mock_cleaners, &cleanup_mock_fn1);
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize - kCleanupNodeSize - 200);
+  CHECK_EQ(b->limit(), 1024ULL - kCleanupNodeSize);
 
-    b->Reset();
-    CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
-    CHECK_EQ(b->Pos() - x, 0LL);
-    CHECK_EQ(b->limit(), 1024ULL);
+  b->Reset();
+  CHECK_EQ(b->remain(), 1024ULL - kBlockHeaderSize);
+  CHECK_EQ(b->Pos() - x, 0LL);
+  CHECK_EQ(b->limit(), 1024ULL);
 
-    CHECK(mock_cleaners->clean1);
-    delete mock_cleaners;
-    mock_cleaners = nullptr;
+  CHECK(mock_cleaners->clean1);
+  delete mock_cleaners;
+  mock_cleaners = nullptr;
 }
 
 TEST_CASE("AlignTest") {
 #if defined(__linux__)
-    SUBCASE("AlignUpToTest8") {
-        CHECK_EQ(AlignUpTo<8>(15UL), 16ULL);
-        CHECK_EQ(AlignUpTo<8>(1UL), 8ULL);
-        CHECK_EQ(AlignUpTo<8>(32UL), 32ULL);
-        CHECK_EQ(AlignUpTo<8>(255UL), 256ULL);
-        CHECK_EQ(AlignUpTo<8>(1024UL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest8") {
+    CHECK_EQ(AlignUpTo<8>(15UL), 16ULL);
+    CHECK_EQ(AlignUpTo<8>(1UL), 8ULL);
+    CHECK_EQ(AlignUpTo<8>(32UL), 32ULL);
+    CHECK_EQ(AlignUpTo<8>(255UL), 256ULL);
+    CHECK_EQ(AlignUpTo<8>(1024UL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest16") {
-        CHECK_EQ(AlignUpTo<16>(15UL), 16ULL);
-        CHECK_EQ(AlignUpTo<16>(1UL), 16ULL);
-        CHECK_EQ(AlignUpTo<16>(32UL), 32ULL);
-        CHECK_EQ(AlignUpTo<16>(255UL), 256ULL);
-        CHECK_EQ(AlignUpTo<16>(1024UL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest16") {
+    CHECK_EQ(AlignUpTo<16>(15UL), 16ULL);
+    CHECK_EQ(AlignUpTo<16>(1UL), 16ULL);
+    CHECK_EQ(AlignUpTo<16>(32UL), 32ULL);
+    CHECK_EQ(AlignUpTo<16>(255UL), 256ULL);
+    CHECK_EQ(AlignUpTo<16>(1024UL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest32") {
-        CHECK_EQ(AlignUpTo<32>(15UL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(1UL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(31UL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(32UL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(255UL), 256ULL);
-        CHECK_EQ(AlignUpTo<32>(1024UL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest32") {
+    CHECK_EQ(AlignUpTo<32>(15UL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(1UL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(31UL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(32UL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(255UL), 256ULL);
+    CHECK_EQ(AlignUpTo<32>(1024UL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest64") {
-        CHECK_EQ(AlignUpTo<64>(15UL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(1UL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(32UL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(63UL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(255UL), 256ULL);
-        CHECK_EQ(AlignUpTo<64>(1024UL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest64") {
+    CHECK_EQ(AlignUpTo<64>(15UL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(1UL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(32UL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(63UL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(255UL), 256ULL);
+    CHECK_EQ(AlignUpTo<64>(1024UL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest128") {
-        CHECK_EQ(AlignUpTo<128>(15UL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(1UL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(32UL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(63UL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(255UL), 256ULL);
-        CHECK_EQ(AlignUpTo<128>(1024UL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest128") {
+    CHECK_EQ(AlignUpTo<128>(15UL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(1UL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(32UL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(63UL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(255UL), 256ULL);
+    CHECK_EQ(AlignUpTo<128>(1024UL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest256") {
-        CHECK_EQ(AlignUpTo<256>(15UL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(1UL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(32UL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(63UL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(255UL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(1024UL), 1024ULL);
-        CHECK_EQ(AlignUpTo<256>(4096UL), 4096ULL);
-    }
+  SUBCASE("AlignUpToTest256") {
+    CHECK_EQ(AlignUpTo<256>(15UL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(1UL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(32UL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(63UL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(255UL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(1024UL), 1024ULL);
+    CHECK_EQ(AlignUpTo<256>(4096UL), 4096ULL);
+  }
 
-    SUBCASE("AlignUpToTest512") {
-        CHECK_EQ(AlignUpTo<512>(15UL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(1UL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(32UL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(63UL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(255UL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(1024UL), 1024ULL);
-        CHECK_EQ(AlignUpTo<512>(4096UL), 4096ULL);
-    }
+  SUBCASE("AlignUpToTest512") {
+    CHECK_EQ(AlignUpTo<512>(15UL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(1UL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(32UL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(63UL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(255UL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(1024UL), 1024ULL);
+    CHECK_EQ(AlignUpTo<512>(4096UL), 4096ULL);
+  }
 
-    SUBCASE("AlignUpToTest4k") {
-        CHECK_EQ(AlignUpTo<4096>(15UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(1UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(32UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(63UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(255UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(1024UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(4096UL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(4099UL), 8192ULL);
-    }
+  SUBCASE("AlignUpToTest4k") {
+    CHECK_EQ(AlignUpTo<4096>(15UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(1UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(32UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(63UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(255UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(1024UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(4096UL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(4099UL), 8192ULL);
+  }
 #else
-    SUBCASE("AlignUpToTest8") {
-        CHECK_EQ(AlignUpTo<8>(15ULL), 16ULL);
-        CHECK_EQ(AlignUpTo<8>(1ULL), 8ULL);
-        CHECK_EQ(AlignUpTo<8>(32ULL), 32ULL);
-        CHECK_EQ(AlignUpTo<8>(255ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<8>(1024ULL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest8") {
+    CHECK_EQ(AlignUpTo<8>(15ULL), 16ULL);
+    CHECK_EQ(AlignUpTo<8>(1ULL), 8ULL);
+    CHECK_EQ(AlignUpTo<8>(32ULL), 32ULL);
+    CHECK_EQ(AlignUpTo<8>(255ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<8>(1024ULL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest16") {
-        CHECK_EQ(AlignUpTo<16>(15ULL), 16ULL);
-        CHECK_EQ(AlignUpTo<16>(1ULL), 16ULL);
-        CHECK_EQ(AlignUpTo<16>(32ULL), 32ULL);
-        CHECK_EQ(AlignUpTo<16>(255ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<16>(1024ULL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest16") {
+    CHECK_EQ(AlignUpTo<16>(15ULL), 16ULL);
+    CHECK_EQ(AlignUpTo<16>(1ULL), 16ULL);
+    CHECK_EQ(AlignUpTo<16>(32ULL), 32ULL);
+    CHECK_EQ(AlignUpTo<16>(255ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<16>(1024ULL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest32") {
-        CHECK_EQ(AlignUpTo<32>(15ULL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(1ULL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(31ULL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(32ULL), 32ULL);
-        CHECK_EQ(AlignUpTo<32>(255ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<32>(1024ULL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest32") {
+    CHECK_EQ(AlignUpTo<32>(15ULL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(1ULL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(31ULL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(32ULL), 32ULL);
+    CHECK_EQ(AlignUpTo<32>(255ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<32>(1024ULL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest64") {
-        CHECK_EQ(AlignUpTo<64>(15ULL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(1ULL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(32ULL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(63ULL), 64ULL);
-        CHECK_EQ(AlignUpTo<64>(255ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<64>(1024ULL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest64") {
+    CHECK_EQ(AlignUpTo<64>(15ULL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(1ULL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(32ULL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(63ULL), 64ULL);
+    CHECK_EQ(AlignUpTo<64>(255ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<64>(1024ULL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest128") {
-        CHECK_EQ(AlignUpTo<128>(15ULL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(1ULL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(32ULL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(63ULL), 128ULL);
-        CHECK_EQ(AlignUpTo<128>(255ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<128>(1024ULL), 1024ULL);
-    }
+  SUBCASE("AlignUpToTest128") {
+    CHECK_EQ(AlignUpTo<128>(15ULL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(1ULL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(32ULL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(63ULL), 128ULL);
+    CHECK_EQ(AlignUpTo<128>(255ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<128>(1024ULL), 1024ULL);
+  }
 
-    SUBCASE("AlignUpToTest256") {
-        CHECK_EQ(AlignUpTo<256>(15ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(1ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(32ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(63ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(255ULL), 256ULL);
-        CHECK_EQ(AlignUpTo<256>(1024ULL), 1024ULL);
-        CHECK_EQ(AlignUpTo<256>(4096ULL), 4096ULL);
-    }
+  SUBCASE("AlignUpToTest256") {
+    CHECK_EQ(AlignUpTo<256>(15ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(1ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(32ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(63ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(255ULL), 256ULL);
+    CHECK_EQ(AlignUpTo<256>(1024ULL), 1024ULL);
+    CHECK_EQ(AlignUpTo<256>(4096ULL), 4096ULL);
+  }
 
-    SUBCASE("AlignUpToTest512") {
-        CHECK_EQ(AlignUpTo<512>(15ULL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(1ULL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(32ULL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(63ULL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(255ULL), 512ULL);
-        CHECK_EQ(AlignUpTo<512>(1024ULL), 1024ULL);
-        CHECK_EQ(AlignUpTo<512>(4096ULL), 4096ULL);
-    }
+  SUBCASE("AlignUpToTest512") {
+    CHECK_EQ(AlignUpTo<512>(15ULL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(1ULL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(32ULL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(63ULL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(255ULL), 512ULL);
+    CHECK_EQ(AlignUpTo<512>(1024ULL), 1024ULL);
+    CHECK_EQ(AlignUpTo<512>(4096ULL), 4096ULL);
+  }
 
-    SUBCASE("AlignUpToTest4k") {
-        CHECK_EQ(AlignUpTo<4096>(15ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(1ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(32ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(63ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(255ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(1024ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(4096ULL), 4096ULL);
-        CHECK_EQ(AlignUpTo<4096>(4099ULL), 8192ULL);
-    }
+  SUBCASE("AlignUpToTest4k") {
+    CHECK_EQ(AlignUpTo<4096>(15ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(1ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(32ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(63ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(255ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(1024ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(4096ULL), 4096ULL);
+    CHECK_EQ(AlignUpTo<4096>(4099ULL), 8192ULL);
+  }
 
 #endif
 
-    // test without on_arena_* trigger
-    SUBCASE("AlignUpTest") {
-        CHECK_EQ(AlignUp(63 + 2048, 1024), 3072ULL);
-        CHECK_EQ(AlignUp(2048, 1024), 2048ULL);
-    }
+  // test without on_arena_* trigger
+  SUBCASE("AlignUpTest") {
+    CHECK_EQ(AlignUp(63 + 2048, 1024), 3072ULL);
+    CHECK_EQ(AlignUp(2048, 1024), 2048ULL);
+  }
 }
 
-class ArenaTest
-{
-   public:
-    Arena::Options ops_complex;
-    Arena::Options ops_simple;
+class ArenaTest {
+public:
+  Arena::Options ops_complex;
+  Arena::Options ops_simple;
 
-    thread_local static alloc_class* mock;
+  thread_local static alloc_class *mock;
 
-    static auto mock_alloc(std::size_t size) -> void* { return mock->alloc(size); }
+  static auto mock_alloc(std::size_t size) -> void * {
+    return mock->alloc(size);
+  }
 
-    static void mock_dealloc(void* ptr) { return mock->dealloc(ptr); }
+  static void mock_dealloc(void *ptr) { return mock->dealloc(ptr); }
 
-    ArenaTest() {
-        // initialize the ops_complex
-        ops_complex.block_alloc = &mock_alloc;
-        ops_complex.block_dealloc = &mock_dealloc;
-        ops_complex.normal_block_size = 1024ULL;
-        ops_complex.suggested_init_block_size = 4096ULL;
-        ops_complex.huge_block_size = 1024ULL * 1024ULL;
-        ops_complex.logger_func = &default_logger_func;
+  ArenaTest() {
+    // initialize the ops_complex
+    ops_complex.block_alloc = &mock_alloc;
+    ops_complex.block_dealloc = &mock_dealloc;
+    ops_complex.normal_block_size = 1024ULL;
+    ops_complex.suggested_init_block_size = 4096ULL;
+    ops_complex.huge_block_size = 1024ULL * 1024ULL;
+    ops_complex.logger_func = &default_logger_func;
 
-        // initialize the ops_simple
-        ops_simple.block_alloc = &mock_alloc;
-        ops_simple.block_dealloc = &mock_dealloc;
-        ops_simple.normal_block_size = 1024ULL;
-        ops_simple.suggested_init_block_size = 1024ULL;
-        ops_simple.huge_block_size = 1024ULL;
-        ops_simple.logger_func = &default_logger_func;
-    }
+    // initialize the ops_simple
+    ops_simple.block_alloc = &mock_alloc;
+    ops_simple.block_dealloc = &mock_dealloc;
+    ops_simple.normal_block_size = 1024ULL;
+    ops_simple.suggested_init_block_size = 1024ULL;
+    ops_simple.huge_block_size = 1024ULL;
+    ops_simple.logger_func = &default_logger_func;
+  }
 };
 
-class ArenaTestHelper
-{
-   public:
-    explicit ArenaTestHelper(Arena& a) : _arena(a) {}
+class ArenaTestHelper {
+public:
+  explicit ArenaTestHelper(Arena &a) : _arena(a) {}
 
-    const Arena::Options& options() { return _arena._options; }
-    [[nodiscard]] uint64_t space_allocated() const { return _arena._space_allocated; }
-    [[nodiscard]] Arena::Block*& last_block() const { return _arena._last_block; }
+  const Arena::Options &options() { return _arena._options; }
+  [[nodiscard]] uint64_t space_allocated() const {
+    return _arena._space_allocated;
+  }
+  [[nodiscard]] Arena::Block *&last_block() const { return _arena._last_block; }
 
-    auto newBlock(uint64_t m, Arena::Block* prev_b) noexcept -> Arena::Block* { return _arena.newBlock(m, prev_b); }
-    auto addCleanup(void* a, void (*cleanup)(void*)) noexcept -> bool { return _arena.addCleanup(a, cleanup); }
-    auto free_blocks_except_head() noexcept -> uint64_t { return _arena.free_blocks_except_head(); }
-    auto free_all_blocks() noexcept -> uint64_t { return _arena.free_all_blocks(); }
-    auto cookie() -> void* { return _arena._cookie; }
+  auto newBlock(uint64_t m, Arena::Block *prev_b) noexcept -> Arena::Block * {
+    auto result = _arena.newBlock(m, prev_b);
+    return result.has_value() ? result.value() : nullptr;
+  }
+  auto addCleanup(void *a, void (*cleanup)(void *)) noexcept -> bool {
+    return _arena.addCleanup(a, cleanup).has_value();
+  }
+  auto free_blocks_except_head() noexcept -> uint64_t {
+    return _arena.free_blocks_except_head();
+  }
+  auto free_all_blocks() noexcept -> uint64_t {
+    return _arena.free_all_blocks();
+  }
+  auto cookie() -> void * { return _arena._cookie; }
 
-   private:
-    Arena& _arena;
+private:
+  Arena &_arena;
 };
 
-thread_local alloc_class* ArenaTest::mock = nullptr;
+thread_local alloc_class *ArenaTest::mock = nullptr;
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.CtorTest") {
-    Arena a(ops_complex);
-    ArenaTestHelper ah(a);
-    CHECK_EQ(ah.last_block(), nullptr);
-    CHECK_EQ(ah.options().normal_block_size, 1024ULL);
-    CHECK_EQ(ah.options().block_alloc == &mock_alloc, true);
-    CHECK_EQ(ah.options().block_dealloc == &mock_dealloc, true);
-    Arena b(ops_simple);
-    ArenaTestHelper bh(b);
-    CHECK_EQ(bh.options().normal_block_size, 1024ULL);
-    CHECK_EQ(bh.options().suggested_init_block_size, 1024ULL);
-    CHECK_EQ(bh.options().huge_block_size, 1024ULL);
-    CHECK_EQ(bh.last_block(), nullptr);
-    CHECK_EQ(bh.options().block_alloc == &mock_alloc, true);
-    CHECK_EQ(bh.options().block_dealloc == &mock_dealloc, true);
-    Arena::Options o = Arena::Options::GetDefaultOptions();
-    o.block_alloc = mock_alloc;
-    o.block_dealloc = mock_dealloc;
-    Arena c(o);
-    ArenaTestHelper ch(c);
-    CHECK_EQ(ch.options().normal_block_size, 4096ULL);
-    CHECK_EQ(ch.options().suggested_init_block_size, 4096ULL);
-    CHECK_EQ(ch.options().huge_block_size, 2ULL * 1024ULL * 1024ULL);
-    CHECK_EQ(ch.options().block_alloc == &mock_alloc, true);
-    CHECK_EQ(ch.options().block_dealloc == &mock_dealloc, true);
+  Arena a(ops_complex);
+  ArenaTestHelper ah(a);
+  CHECK_EQ(ah.last_block(), nullptr);
+  CHECK_EQ(ah.options().normal_block_size, 1024ULL);
+  CHECK_EQ(ah.options().block_alloc == &mock_alloc, true);
+  CHECK_EQ(ah.options().block_dealloc == &mock_dealloc, true);
+  Arena b(ops_simple);
+  ArenaTestHelper bh(b);
+  CHECK_EQ(bh.options().normal_block_size, 1024ULL);
+  CHECK_EQ(bh.options().suggested_init_block_size, 1024ULL);
+  CHECK_EQ(bh.options().huge_block_size, 1024ULL);
+  CHECK_EQ(bh.last_block(), nullptr);
+  CHECK_EQ(bh.options().block_alloc == &mock_alloc, true);
+  CHECK_EQ(bh.options().block_dealloc == &mock_dealloc, true);
+  Arena::Options o = Arena::Options::GetDefaultOptions();
+  o.block_alloc = mock_alloc;
+  o.block_dealloc = mock_dealloc;
+  Arena c(o);
+  ArenaTestHelper ch(c);
+  CHECK_EQ(ch.options().normal_block_size, 4096ULL);
+  CHECK_EQ(ch.options().suggested_init_block_size, 4096ULL);
+  CHECK_EQ(ch.options().huge_block_size, 2ULL * 1024ULL * 1024ULL);
+  CHECK_EQ(ch.options().block_alloc == &mock_alloc, true);
+  CHECK_EQ(ch.options().block_dealloc == &mock_dealloc, true);
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.NewBlockTest") {
-    // the case bearing the a and b is leaking.
-    // because I just want to test the NewBlock
-    auto* a = new Arena(ops_simple);
-    mock = new alloc_class;
-    ArenaTestHelper ah(*a);
-    Arena::Block* bb = ah.newBlock(100, nullptr);
-    CHECK_EQ(bb, mock->ptrs.front());
-    CHECK_EQ(ah.space_allocated(), 1024ULL);
-    CHECK_EQ(bb->remain(), 1024 - kBlockHeaderSize);
+  // the case bearing the a and b is leaking.
+  // because I just want to test the NewBlock
+  auto *a = new Arena(ops_simple);
+  mock = new alloc_class;
+  ArenaTestHelper ah(*a);
+  Arena::Block *bb = ah.newBlock(100, nullptr);
+  CHECK_EQ(bb, mock->ptrs.front());
+  CHECK_EQ(ah.space_allocated(), 1024ULL);
+  CHECK_EQ(bb->remain(), 1024 - kBlockHeaderSize);
 
-    auto* b = new Arena(ops_complex);
-    ArenaTestHelper bh(*b);
-    // will ignore the init block from building cleanups
-    // this situation will never occurs in the real world.
-    auto* xx = bh.newBlock(200, nullptr);
-    CHECK_EQ(xx, mock->ptrs.back());
+  auto *b = new Arena(ops_complex);
+  ArenaTestHelper bh(*b);
+  // will ignore the init block from building cleanups
+  // this situation will never occurs in the real world.
+  auto *xx = bh.newBlock(200, nullptr);
+  CHECK_EQ(xx, mock->ptrs.back());
 
-    bb = bh.newBlock(2500, bb);
+  bb = bh.newBlock(2500, bb);
 
-    bb = bh.newBlock(300 * 1024 + 100, bb);
+  bb = bh.newBlock(300 * 1024 + 100, bb);
 
-    bb = bh.newBlock(2 * 1024 * 1024, bb);
-    auto* bb1 = bh.newBlock(2 * 1024 * 1024, bb);
-    CHECK_EQ(bb1, mock->ptrs.back());
-    CHECK_EQ(bb1->prev(), bb);
-    // cleanup
-    delete mock;
-    mock = nullptr;
-    delete a;
-    delete b;
+  bb = bh.newBlock(2 * 1024 * 1024, bb);
+  auto *bb1 = bh.newBlock(2 * 1024 * 1024, bb);
+  CHECK_EQ(bb1, mock->ptrs.back());
+  CHECK_EQ(bb1->prev(), bb);
+  // cleanup
+  delete mock;
+  mock = nullptr;
+  delete a;
+  delete b;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.AllocateTest") {
-    mock = new alloc_class;
-    auto* x = new Arena(ops_complex);
-    auto* new_ptr = x->AllocateAligned(3500);
-    CHECK_EQ(new_ptr, static_cast<char*>(mock->init) + sizeof(Arena::Block));
+  mock = new alloc_class;
+  auto *x = new Arena(ops_complex);
+  auto new_result = x->AllocateAligned(3500);
+  REQUIRE(new_result.has_value());
+  auto *new_ptr = new_result.value();
+  CHECK_EQ(new_ptr, static_cast<char *>(mock->init) + sizeof(Arena::Block));
 
-    auto* next_ptr = x->AllocateAligned(755);
+  auto next_result = x->AllocateAligned(755);
+  REQUIRE(next_result.has_value());
+  auto *next_ptr = next_result.value();
 
-    CHECK_EQ(next_ptr, static_cast<char*>(mock->ptrs.back()) + sizeof(Arena::Block));
-    delete x;
-    CHECK_EQ(mock->free_ptrs.size(), 2);
-    CHECK_EQ(mock->free_ptrs.front(), mock->ptrs.back());
-    CHECK_EQ(mock->free_ptrs.back(), mock->ptrs.front());
-    delete mock;
-    mock = nullptr;
+  CHECK_EQ(next_ptr,
+           static_cast<char *>(mock->ptrs.back()) + sizeof(Arena::Block));
+  delete x;
+  CHECK_EQ(mock->free_ptrs.size(), 2);
+  CHECK_EQ(mock->free_ptrs.front(), mock->ptrs.back());
+  CHECK_EQ(mock->free_ptrs.back(), mock->ptrs.front());
+  delete mock;
+  mock = nullptr;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.AddCleanupTest") {
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-    auto* a = new Arena(ops_complex);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
-    mock_cleaners = new cleanup_mock;
-    bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
-    CHECK(ok);
-    CHECK_EQ(1, a->cleanups());
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+  auto *a = new Arena(ops_complex);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
+  mock_cleaners = new cleanup_mock;
+  bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
+  CHECK(ok);
+  CHECK_EQ(1, a->cleanups());
 
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-    void* obj = malloc(120);  // will be free automatically
-    bool ok2 = false;
-    ok2 = ah.addCleanup(obj, &std::free);
-    CHECK(ok2);
-    CHECK_EQ(2, a->cleanups());
-    CHECK_EQ(ah.last_block()->remain(), ah.last_block()->size() - kBlockHeaderSize - kCleanupNodeSize * 2);
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+  void *obj = malloc(120); // will be free automatically
+  bool ok2 = false;
+  ok2 = ah.addCleanup(obj, &std::free);
+  CHECK(ok2);
+  CHECK_EQ(2, a->cleanups());
+  CHECK_EQ(ah.last_block()->remain(),
+           ah.last_block()->size() - kBlockHeaderSize - kCleanupNodeSize * 2);
 
-    CHECK_EQ(mock->alloc_sizes.front(), 4096);
-    delete a;
-    delete mock;
-    delete mock_cleaners;
+  CHECK_EQ(mock->alloc_sizes.front(), 4096);
+  delete a;
+  delete mock;
+  delete mock_cleaners;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.AddCleanupFailTest") {
-    auto* a = new Arena(ops_complex);
-    mock = new alloc_fail_class;
-    ArenaTestHelper ah(*a);
-    // this line means malloc failed, so no space for cleanup Node.
+  auto *a = new Arena(ops_complex);
+  mock = new alloc_fail_class;
+  ArenaTestHelper ah(*a);
+  // this line means malloc failed, so no space for cleanup Node.
 
-    mock_cleaners = new cleanup_mock;
-    bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
-    CHECK_FALSE(ok);
+  mock_cleaners = new cleanup_mock;
+  bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
+  CHECK_FALSE(ok);
 
-    CHECK_EQ(mock->alloc_sizes.size(), 0);
-    delete a;
-    delete mock;
-    delete mock_cleaners;
+  CHECK_EQ(mock->alloc_sizes.size(), 0);
+  delete a;
+  delete mock;
+  delete mock_cleaners;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.FreeBlocksExceptFirstTest") {
-    auto* a = new Arena(ops_simple);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
+  auto *a = new Arena(ops_simple);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
 
-    ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
-    CHECK_EQ(ah.last_block(), mock->ptrs.back());
-    CHECK_EQ(mock->alloc_sizes.back(), 1024);
-    ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
-    CHECK_EQ(ah.last_block(), mock->ptrs.back());
-    CHECK_EQ(mock->alloc_sizes.back(), 2048);
-    ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
-    CHECK_EQ(ah.last_block(), mock->ptrs.back());
-    CHECK_EQ(mock->alloc_sizes.back(), 4096);
+  ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
+  CHECK_EQ(ah.last_block(), mock->ptrs.back());
+  CHECK_EQ(mock->alloc_sizes.back(), 1024);
+  ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
+  CHECK_EQ(ah.last_block(), mock->ptrs.back());
+  CHECK_EQ(mock->alloc_sizes.back(), 2048);
+  ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
+  CHECK_EQ(ah.last_block(), mock->ptrs.back());
+  CHECK_EQ(mock->alloc_sizes.back(), 4096);
 
-    // FreeBlocks should not be call out of the class, just use ~Arena
-    auto wasted = ah.free_blocks_except_head();
-    CHECK_EQ(wasted, 1024 * 7 - 3 * kBlockHeaderSize);
-    CHECK_EQ(mock->free_ptrs.size(), 2);
+  // FreeBlocks should not be call out of the class, just use ~Arena
+  auto wasted = ah.free_blocks_except_head();
+  CHECK_EQ(wasted, 1024 * 7 - 3 * kBlockHeaderSize);
+  CHECK_EQ(mock->free_ptrs.size(), 2);
 
-    // set last_block_ to nullptr, to avoid the dealloc for this block.
-    ah.last_block() = nullptr;
-    delete a;
-    delete mock;
+  // set last_block_ to nullptr, to avoid the dealloc for this block.
+  ah.last_block() = nullptr;
+  delete a;
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.ResetTest") {
-    auto* a = new Arena(ops_simple);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
+  auto *a = new Arena(ops_simple);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
 
-    ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
-    ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
-    ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
+  ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
 
-    a->Reset();
-    CHECK_EQ(mock->free_ptrs.size(), 2);
+  a->Reset();
+  CHECK_EQ(mock->free_ptrs.size(), 2);
 
-    CHECK_EQ(ah.last_block(), mock->ptrs.front());
-    CHECK_EQ(ah.space_allocated(), 1024);
-    CHECK_EQ(ah.last_block()->remain(), 1024 - kBlockHeaderSize);
+  CHECK_EQ(ah.last_block(), mock->ptrs.front());
+  CHECK_EQ(ah.space_allocated(), 1024);
+  CHECK_EQ(ah.last_block()->remain(), 1024 - kBlockHeaderSize);
 
-    // set last_block_ to nullptr, to avoid the dealloc for this block.
-    ah.last_block() = nullptr;
-    delete a;
-    delete mock;
+  // set last_block_ to nullptr, to avoid the dealloc for this block.
+  ah.last_block() = nullptr;
+  delete a;
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.ResetWithCleanupTest") {
-    auto* a = new Arena(ops_simple);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
-    mock_cleaners = new cleanup_mock;
+  auto *a = new Arena(ops_simple);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
+  mock_cleaners = new cleanup_mock;
 
-    ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
-    ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
-    ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
+  ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
 
-    bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
-    CHECK(ok);
+  bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
+  CHECK(ok);
 
-    a->Reset();
+  a->Reset();
 
-    CHECK(mock_cleaners->clean1);
-    CHECK_EQ(ah.last_block(), mock->ptrs.front());
-    CHECK_EQ(ah.space_allocated(), 1024);
-    CHECK_EQ(ah.last_block()->remain(), 1024 - kBlockHeaderSize);
+  CHECK(mock_cleaners->clean1);
+  CHECK_EQ(ah.last_block(), mock->ptrs.front());
+  CHECK_EQ(ah.space_allocated(), 1024);
+  CHECK_EQ(ah.last_block()->remain(), 1024 - kBlockHeaderSize);
 
-    // set last_block_ to nullptr, to avoid the dealloc for this block.
-    ah.last_block() = nullptr;
-    delete a;
-    delete mock_cleaners;
-    delete mock;
+  // set last_block_ to nullptr, to avoid the dealloc for this block.
+  ah.last_block() = nullptr;
+  delete a;
+  delete mock_cleaners;
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.FreeBlocksTest") {
-    auto* a = new Arena(ops_simple);
-    mock = new alloc_class;
-    ArenaTestHelper ah(*a);
+  auto *a = new Arena(ops_simple);
+  mock = new alloc_class;
+  ArenaTestHelper ah(*a);
 
-    ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
-    ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
-    ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
+  ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
 
-    auto wasted = ah.free_all_blocks();
-    CHECK_EQ(wasted, 7 * 1024 - 3 * kBlockHeaderSize);
-    CHECK_EQ(mock->free_ptrs.size(), 3);
+  auto wasted = ah.free_all_blocks();
+  CHECK_EQ(wasted, 7 * 1024 - 3 * kBlockHeaderSize);
+  CHECK_EQ(mock->free_ptrs.size(), 3);
 
-    delete a;
-    delete mock;
+  delete a;
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.DoCleanupTest") {
-    auto* a = new Arena(ops_complex);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
-    mock_cleaners = new cleanup_mock;
-    bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
-    CHECK(ok);
+  auto *a = new Arena(ops_complex);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
+  mock_cleaners = new cleanup_mock;
+  bool ok = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
+  CHECK(ok);
 
-    delete a;
-    CHECK(mock_cleaners->clean1);
-    delete mock_cleaners;
-    delete mock;
+  delete a;
+  CHECK(mock_cleaners->clean1);
+  delete mock_cleaners;
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.to_string<pmr::string>") {
-    auto* a = new Arena(ops_simple);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
-    std::string str = "this is a very very long string that need to be allocated on arena";
-    std::string s;
+  auto *a = new Arena(ops_simple);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
+  std::string str =
+      "this is a very very long string that need to be allocated on arena";
+  std::string s;
 
-    {
-        ::pmr::string pmr_str(str, a->get_memory_resource());
-        CHECK_EQ(ah.space_allocated(), 1024ULL);
-        CHECK_EQ(strcmp(pmr_str.c_str(), str.c_str()), 0);
-    }
+  {
+    ::pmr::string pmr_str(str, a->get_memory_resource());
+    CHECK_EQ(ah.space_allocated(), 1024ULL);
+    CHECK_EQ(strcmp(pmr_str.c_str(), str.c_str()), 0);
+  }
 
-    delete a;
-    CHECK_EQ(mock->ptrs.size(), 1);
-    CHECK_EQ(mock->free_ptrs.size(), 1);
-    CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
-    CHECK_EQ(mock->alloc_sizes.front(), 1024);
-    delete mock;
+  delete a;
+  CHECK_EQ(mock->ptrs.size(), 1);
+  CHECK_EQ(mock->free_ptrs.size(), 1);
+  CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
+  CHECK_EQ(mock->alloc_sizes.front(), 1024);
+  delete mock;
 }
 
-class mock_own
-{
-   public:
-    mock_own() { count++; }
-    ~mock_own() { count--; }
-    inline static int count = 0;
+class mock_own {
+public:
+  mock_own() { count++; }
+  ~mock_own() { count--; }
+  inline static int count = 0;
 };
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.OwnTest") {
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-    auto* m = new mock_own();
-    auto* a = new Arena(ops_complex);
-    mock = new alloc_class;
-    bool ok = a->Own<mock_own>(m);
-    CHECK(ok);
-    delete a;
-    CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
-    CHECK_EQ(mock_own::count, 0);
-    delete mock;
-    mock = nullptr;
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+  auto *m = new mock_own();
+  auto *a = new Arena(ops_complex);
+  mock = new alloc_class;
+  auto ok = a->Own<mock_own>(m);
+  CHECK(ok.has_value());
+  delete a;
+  CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
+  CHECK_EQ(mock_own::count, 0);
+  delete mock;
+  mock = nullptr;
 }
 
-struct mock_struct
-{
-    int i;
-    char c;
-    double rate;
-    void* p;
+struct mock_struct {
+  int i;
+  char c;
+  double rate;
+  void *p;
 };
 
-class cstr_class
-{
-   public:
-    void construct(const std::string& input) {
-        name = input;
-        count++;
-    }
-    void destruct(const std::string& input) {
-        name = input;
-        count--;
-    }
-    std::string name{};
-    inline static int count = 0;
+class cstr_class {
+public:
+  void construct(const std::string &input) {
+    name = input;
+    count++;
+  }
+  void destruct(const std::string &input) {
+    name = input;
+    count--;
+  }
+  std::string name{};
+  inline static int count = 0;
 };
 
-thread_local cstr_class* cstr;
+thread_local cstr_class *cstr;
 
-class mock_class_need_dstr
-{
-   public:
-    ArenaFullManagedTag;
-    mock_class_need_dstr(int i, std::string name) : index_(i), n_(std::move(name)) { cstr->construct(n_); }
-    ~mock_class_need_dstr() { cstr->destruct(n_); }
-    auto verify(int i, const std::string& name) -> bool { return (i == index_) && (name == n_); }
+class mock_class_need_dstr {
+public:
+  ArenaFullManagedTag;
+  mock_class_need_dstr(int i, std::string name)
+      : index_(i), n_(std::move(name)) {
+    cstr->construct(n_);
+  }
+  ~mock_class_need_dstr() { cstr->destruct(n_); }
+  auto verify(int i, const std::string &name) -> bool {
+    return (i == index_) && (name == n_);
+  }
 
-   private:
-    int index_;
-    const std::string n_;
+private:
+  int index_;
+  const std::string n_;
 };
 
-class mock_class_without_dstr
-{
-   public:
-    ArenaManagedCreateOnlyTag;
-    static void construct() { count++; }
-    static void destruct() { count--; }
-    // NOLINTNEXTLINE
-    explicit mock_class_without_dstr(std::string name) : n_(std::move(name)) { cstr->construct(n_); }
-    ~mock_class_without_dstr() { cstr->destruct(n_); }
-    auto verify(const std::string& n) -> bool { return n_ == n; }
+class mock_class_without_dstr {
+public:
+  ArenaManagedCreateOnlyTag;
+  static void construct() { count++; }
+  static void destruct() { count--; }
+  // NOLINTNEXTLINE
+  explicit mock_class_without_dstr(std::string name) : n_(std::move(name)) {
+    cstr->construct(n_);
+  }
+  ~mock_class_without_dstr() { cstr->destruct(n_); }
+  auto verify(const std::string &n) -> bool { return n_ == n; }
 
-   private:
-    const std::string n_;
-    inline static int count = 0;
+private:
+  const std::string n_;
+  inline static int count = 0;
 };
 
-class mock_class_with_arena
-{
-   public:
-    ArenaFullManagedTag;
-    // explicit mock_class_with_arena(Arena* arena) : arena_(arena) {}
-    mock_class_with_arena() = default;
+class mock_class_with_arena {
+public:
+  ArenaFullManagedTag;
+  // explicit mock_class_with_arena(Arena* arena) : arena_(arena) {}
+  mock_class_with_arena() = default;
 
-   private:
-    // Arena* arena_{nullptr};
+private:
+  // Arena* arena_{nullptr};
 };
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.CreateTest") {
-    mock = new alloc_class;
-    cstr = new cstr_class;
-    auto* a = new Arena(ops_complex);
-    ArenaTestHelper ah(*a);
-    std::string ss("hello world");
-    std::string sss("fuck the world");
+  mock = new alloc_class;
+  cstr = new cstr_class;
+  auto *a = new Arena(ops_complex);
+  ArenaTestHelper ah(*a);
+  std::string ss("hello world");
+  std::string sss("fuck the world");
 
-    auto* d2 = a->Create<mock_class_without_dstr>("fuck the world");
-    CHECK_EQ(mock->alloc_sizes.front(), 4096);
-    CHECK_EQ(0, a->cleanups());
+  auto d2_result = a->Create<mock_class_without_dstr>("fuck the world");
+  REQUIRE(d2_result.has_value());
+  auto *d2 = d2_result.value();
+  CHECK_EQ(mock->alloc_sizes.front(), 4096);
+  CHECK_EQ(0, a->cleanups());
 
-    auto* d1 = a->Create<mock_class_need_dstr>(3, ss);
-    CHECK_EQ(1, a->cleanups());
-    CHECK(d1->verify(3, ss));
-    CHECK(d2->verify(sss));
+  auto d1_result = a->Create<mock_class_need_dstr>(3, ss);
+  REQUIRE(d1_result.has_value());
+  auto *d1 = d1_result.value();
+  CHECK_EQ(1, a->cleanups());
+  CHECK(d1->verify(3, ss));
+  CHECK(d2->verify(sss));
 
-    auto r1 = ah.last_block()->remain();
-    auto* r = a->Create<mock_struct>();
-    CHECK(r != nullptr);
-    CHECK_EQ(1, a->cleanups());  // mock_struct will not be register to cleanup
-    auto r2 = ah.last_block()->remain();
-    CHECK_EQ(r1 - r2, sizeof(mock_struct));
+  auto r1 = ah.last_block()->remain();
+  auto r_result = a->Create<mock_struct>();
+  REQUIRE(r_result.has_value());
+  auto *r = r_result.value();
+  CHECK(r != nullptr);
+  CHECK_EQ(1, a->cleanups()); // mock_struct will not be register to cleanup
+  auto r2 = ah.last_block()->remain();
+  CHECK_EQ(r1 - r2, sizeof(mock_struct));
 
-    // auto pass Arena*
-    (void)a->Create<mock_class_with_arena>();
-    CHECK_EQ(cstr->count, 2);
+  // auto pass Arena*
+  auto arena_result = a->Create<mock_class_with_arena>();
+  REQUIRE(arena_result.has_value());
+  CHECK_EQ(cstr->count, 2);
 
-    delete a;
+  delete a;
 
-    CHECK_EQ(mock->free_ptrs.size(), 1);
-    CHECK_EQ(cstr->count, 1);
-    delete mock;
-    delete cstr;
+  CHECK_EQ(mock->free_ptrs.size(), 1);
+  CHECK_EQ(cstr->count, 1);
+  delete mock;
+  delete cstr;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.CreateArrayTest") {
-    mock = new alloc_class;
-    auto* a = new Arena(ops_complex);
-    ArenaTestHelper ah(*a);
+  mock = new alloc_class;
+  auto *a = new Arena(ops_complex);
+  ArenaTestHelper ah(*a);
 
-    auto* r = a->CreateArray<uint64_t>(10);
-    CHECK(r != nullptr);
-    uint64_t s2 = ah.last_block()->remain();
-    CHECK_EQ(s2, 4096 - kBlockHeaderSize - 10 * sizeof(uint64_t));
+  auto r_result = a->CreateArray<uint64_t>(10);
+  REQUIRE(r_result.has_value());
+  auto *r = r_result.value();
+  CHECK(r != nullptr);
+  uint64_t s2 = ah.last_block()->remain();
+  CHECK_EQ(s2, 4096 - kBlockHeaderSize - 10 * sizeof(uint64_t));
 
-    struct test_struct
-    {
-        int i;
-        char n;
-        double d;
-    };
+  struct test_struct {
+    int i;
+    char n;
+    double d;
+  };
 
-    auto* r1 = a->CreateArray<test_struct>(10);
-    CHECK(r1 != nullptr);
-    uint64_t s3 = ah.last_block()->remain();
+  auto r1_result = a->CreateArray<test_struct>(10);
+  REQUIRE(r1_result.has_value());
+  auto *r1 = r1_result.value();
+  CHECK(r1 != nullptr);
+  uint64_t s3 = ah.last_block()->remain();
 
-    CHECK_EQ(s3, 4096ULL - kBlockHeaderSize - 10ULL * sizeof(uint64_t) - 10ULL * sizeof(test_struct));
-    // auto pass Arena*
-    (void)a->CreateArray<mock_class_with_arena>(10);
+  CHECK_EQ(s3, 4096ULL - kBlockHeaderSize - 10ULL * sizeof(uint64_t) -
+                   10ULL * sizeof(test_struct));
+  // auto pass Arena*
+  auto arena_arr_result = a->CreateArray<mock_class_with_arena>(10);
+  REQUIRE(arena_arr_result.has_value());
 
-    delete a;
-    CHECK_EQ(mock->free_ptrs.size(), 1);
-    delete mock;
+  delete a;
+  CHECK_EQ(mock->free_ptrs.size(), 1);
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.DstrTest") {
-    auto* a = new Arena(ops_simple);
-    ArenaTestHelper ah(*a);
-    mock = new alloc_class;
-    mock_cleaners = new cleanup_mock;
-    ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
-    ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
-    ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
+  auto *a = new Arena(ops_simple);
+  ArenaTestHelper ah(*a);
+  mock = new alloc_class;
+  mock_cleaners = new cleanup_mock;
+  ah.last_block() = ah.newBlock(1024 - kBlockHeaderSize, nullptr);
+  ah.last_block() = ah.newBlock(2048 - kBlockHeaderSize, ah.last_block());
+  ah.last_block() = ah.newBlock(4096 - kBlockHeaderSize, ah.last_block());
 
-    bool ok1 = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
-    bool ok2 = ah.addCleanup(mock_cleaners, &cleanup_mock_fn2);
-    bool ok3 = ah.addCleanup(mock_cleaners, &cleanup_mock_fn3);
-    CHECK(ok1);
-    CHECK(ok2);
-    CHECK(ok3);
+  bool ok1 = ah.addCleanup(mock_cleaners, &cleanup_mock_fn1);
+  bool ok2 = ah.addCleanup(mock_cleaners, &cleanup_mock_fn2);
+  bool ok3 = ah.addCleanup(mock_cleaners, &cleanup_mock_fn3);
+  CHECK(ok1);
+  CHECK(ok2);
+  CHECK(ok3);
 
-    delete a;
-    CHECK_EQ(mock->free_ptrs.size(), 3);
-    CHECK(mock_cleaners->clean1);
-    CHECK(mock_cleaners->clean2);
-    CHECK(mock_cleaners->clean3);
-    delete mock;
-    delete mock_cleaners;
+  delete a;
+  CHECK_EQ(mock->free_ptrs.size(), 3);
+  CHECK(mock_cleaners->clean1);
+  CHECK(mock_cleaners->clean2);
+  CHECK(mock_cleaners->clean3);
+  delete mock;
+  delete mock_cleaners;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.SpaceTest") {
-    auto* x = new Arena(ops_complex);
-    ArenaTestHelper xh(*x);
-    mock = new alloc_class;
-    CHECK_EQ(x->SpaceAllocated(), 0ULL);
+  auto *x = new Arena(ops_complex);
+  ArenaTestHelper xh(*x);
+  mock = new alloc_class;
+  CHECK_EQ(x->SpaceAllocated(), 0ULL);
 
-    auto* new_ptr = x->AllocateAligned(3500);
-    CHECK_EQ(new_ptr, static_cast<char*>(mock->ptrs.front()) + sizeof(Arena::Block));
+  auto new_result = x->AllocateAligned(3500);
+  REQUIRE(new_result.has_value());
+  auto *new_ptr = new_result.value();
+  CHECK_EQ(new_ptr,
+           static_cast<char *>(mock->ptrs.front()) + sizeof(Arena::Block));
 
-    auto* next_ptr = x->AllocateAligned(755);
-    CHECK_EQ(next_ptr, static_cast<char*>(mock->ptrs.back()) + sizeof(Arena::Block));
+  auto next_result = x->AllocateAligned(755);
+  REQUIRE(next_result.has_value());
+  auto *next_ptr = next_result.value();
+  CHECK_EQ(next_ptr,
+           static_cast<char *>(mock->ptrs.back()) + sizeof(Arena::Block));
 
-    CHECK_EQ(x->SpaceAllocated(), 5120ULL);
-    CHECK_EQ(xh.last_block(), mock->ptrs.back());
+  CHECK_EQ(x->SpaceAllocated(), 5120ULL);
+  CHECK_EQ(xh.last_block(), mock->ptrs.back());
 
-    delete x;
-    CHECK_EQ(mock->free_ptrs.size(), 2);
-    delete mock;
+  delete x;
+  CHECK_EQ(mock->free_ptrs.size(), 2);
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.RemainsTest") {
-    auto* x = new Arena(ops_complex);
-    ArenaTestHelper xh(*x);
-    mock = new alloc_class;
-    CHECK_EQ(x->SpaceAllocated(), 0ULL);
+  auto *x = new Arena(ops_complex);
+  ArenaTestHelper xh(*x);
+  mock = new alloc_class;
+  CHECK_EQ(x->SpaceAllocated(), 0ULL);
 
-    auto* new_ptr = x->AllocateAligned(3500);
-    CHECK_EQ(new_ptr, static_cast<char*>(mock->ptrs.front()) + sizeof(Arena::Block));
+  auto new_result = x->AllocateAligned(3500);
+  REQUIRE(new_result.has_value());
+  auto *new_ptr = new_result.value();
+  CHECK_EQ(new_ptr,
+           static_cast<char *>(mock->ptrs.front()) + sizeof(Arena::Block));
 
-    auto* next_ptr = x->AllocateAligned(755);
-    CHECK_EQ(next_ptr, static_cast<char*>(mock->ptrs.back()) + sizeof(Arena::Block));
+  auto next_result = x->AllocateAligned(755);
+  REQUIRE(next_result.has_value());
+  auto *next_ptr = next_result.value();
+  CHECK_EQ(next_ptr,
+           static_cast<char *>(mock->ptrs.back()) + sizeof(Arena::Block));
 
-    CHECK_EQ(x->SpaceRemains(), 1024ULL - kBlockHeaderSize - 760);
-    CHECK_EQ(xh.last_block(), mock->ptrs.back());
+  CHECK_EQ(x->SpaceRemains(), 1024ULL - kBlockHeaderSize - 760);
+  CHECK_EQ(xh.last_block(), mock->ptrs.back());
 
-    delete x;
-    CHECK_EQ(mock->free_ptrs.size(), 2);
-    delete mock;
+  delete x;
+  CHECK_EQ(mock->free_ptrs.size(), 2);
+  delete mock;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.AllocateAlignedAndAddCleanupTest") {
-    auto* a = new Arena(ops_complex);
-    mock_cleaners = new cleanup_mock;
-    mock = new alloc_class;
-    auto* new_ptr = a->AllocateAlignedAndAddCleanup(3500, cleanup_mock_fn1, mock_cleaners);
-    CHECK_EQ(new_ptr, static_cast<char*>(mock->ptrs.front()) + sizeof(Arena::Block));
+  auto *a = new Arena(ops_complex);
+  mock_cleaners = new cleanup_mock;
+  mock = new alloc_class;
+  auto new_result =
+      a->AllocateAlignedAndAddCleanup(3500, cleanup_mock_fn1, mock_cleaners);
+  REQUIRE(new_result.has_value());
+  auto *new_ptr = new_result.value();
+  CHECK_EQ(new_ptr,
+           static_cast<char *>(mock->ptrs.front()) + sizeof(Arena::Block));
 
-    auto* next_ptr = a->AllocateAlignedAndAddCleanup(755, cleanup_mock_fn2, mock_cleaners);
+  auto next_result =
+      a->AllocateAlignedAndAddCleanup(755, cleanup_mock_fn2, mock_cleaners);
+  REQUIRE(next_result.has_value());
+  auto *next_ptr = next_result.value();
 
-    CHECK_EQ(next_ptr, static_cast<char*>(mock->ptrs.back()) + sizeof(Arena::Block));
-    delete a;
-    CHECK_EQ(mock->free_ptrs.size(), 2);
-    delete mock;
-    CHECK(mock_cleaners->clean1);
-    CHECK(mock_cleaners->clean2);
-    delete mock_cleaners;
+  CHECK_EQ(next_ptr,
+           static_cast<char *>(mock->ptrs.back()) + sizeof(Arena::Block));
+  delete a;
+  CHECK_EQ(mock->free_ptrs.size(), 2);
+  delete mock;
+  CHECK(mock_cleaners->clean1);
+  CHECK(mock_cleaners->clean2);
+  delete mock_cleaners;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("ArenaTest.CheckTest") {
-    struct destructible
-    {
-        ArenaFullManagedTag;
-        destructible() : to_free{new char[5]} {}
-        ~destructible() { delete[] to_free; }
-        int x{0};
-        char* to_free;
-    };
-    struct skip_destructible
-    {
-        ArenaManagedCreateOnlyTag;
-        skip_destructible() = default;
-        ~skip_destructible() = default;
-        int z{0};
-    };
-    Arena::Options realops = Arena::Options::GetDefaultOptions();
-    Arena a(realops);
-    int x = 0;
-    std::string ss = "with dstr";
-    std::unique_ptr<int> ptr = std::make_unique<int>();
-    auto* arena_managed_ptr = a.AllocateAligned(100);
-    auto* with_dstr = a.Create<destructible>();
-    auto* without_dstr = a.Create<skip_destructible>();
-    ArenaTestHelper helper(a);
-    auto* block = helper.last_block();
+  struct destructible {
+    ArenaFullManagedTag;
+    destructible() : to_free{new char[5]} {}
+    ~destructible() { delete[] to_free; }
+    int x{0};
+    char *to_free;
+  };
+  struct skip_destructible {
+    ArenaManagedCreateOnlyTag;
+    skip_destructible() = default;
+    ~skip_destructible() = default;
+    int z{0};
+  };
+  Arena::Options realops = Arena::Options::GetDefaultOptions();
+  Arena a(realops);
+  int x = 0;
+  std::string ss = "with dstr";
+  std::unique_ptr<int> ptr = std::make_unique<int>();
+  auto arena_managed_result = a.AllocateAligned(100);
+  REQUIRE(arena_managed_result.has_value());
+  auto *arena_managed_ptr = arena_managed_result.value();
+  auto with_dstr_result = a.Create<destructible>();
+  REQUIRE(with_dstr_result.has_value());
+  auto *with_dstr = with_dstr_result.value();
+  auto without_dstr_result = a.Create<skip_destructible>();
+  REQUIRE(without_dstr_result.has_value());
+  auto *without_dstr = without_dstr_result.value();
+  ArenaTestHelper helper(a);
+  auto *block = helper.last_block();
 
-    CHECK_EQ(a.check(reinterpret_cast<char*>(block)), ArenaContainStatus::BlockHeader);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(&x)), ArenaContainStatus::NotContain);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(ptr.get())), ArenaContainStatus::NotContain);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(with_dstr)), ArenaContainStatus::BlockUsed);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(without_dstr)), ArenaContainStatus::BlockUsed);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(arena_managed_ptr)), ArenaContainStatus::BlockUsed);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(with_dstr) + 200), ArenaContainStatus::BlockUnUsed);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(block) + 4090), ArenaContainStatus::BlockCleanup);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(block) + block->size() - kCleanupNodeSize),
-             ArenaContainStatus::BlockCleanup);
-    CHECK_EQ(a.check(reinterpret_cast<char*>(block) + block->size()), ArenaContainStatus::NotContain);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(block)),
+           ArenaContainStatus::BlockHeader);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(&x)),
+           ArenaContainStatus::NotContain);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(ptr.get())),
+           ArenaContainStatus::NotContain);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(with_dstr)),
+           ArenaContainStatus::BlockUsed);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(without_dstr)),
+           ArenaContainStatus::BlockUsed);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(arena_managed_ptr)),
+           ArenaContainStatus::BlockUsed);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(with_dstr) + 200),
+           ArenaContainStatus::BlockUnUsed);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(block) + 4090),
+           ArenaContainStatus::BlockCleanup);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(block) + block->size() -
+                   kCleanupNodeSize),
+           ArenaContainStatus::BlockCleanup);
+  CHECK_EQ(a.check(reinterpret_cast<char *>(block) + block->size()),
+           ArenaContainStatus::NotContain);
 }
 
-class mock_hook
-{
-   public:
-    explicit mock_hook(void* cookie) : _cookie(cookie) {}
-    auto arena_init_hook(Arena* /*unused*/) -> void* {
-        inited++;
-        return _cookie;
-    }
-    void arena_allocate_hook(const std::type_info* /*unused*/, uint64_t /*unused*/, void* /*unused*/) { allocated++; }
-    auto arena_destruction_hook(Arena* /*unused*/, void* /*unused*/, uint64_t /*unused*/, uint64_t /*unused*/)
-      -> void* {
-        destructed++;
-        return _cookie;
-    }
-    void arena_reset_hook(Arena* /*unused*/, void* /*unused*/, uint64_t /*unused*/, uint64_t /*unused*/) { reseted++; }
-    int inited = 0;
-    int allocated = 0;
-    int destructed = 0;
-    int reseted = 0;
+class mock_hook {
+public:
+  explicit mock_hook(void *cookie) : _cookie(cookie) {}
+  auto arena_init_hook(Arena * /*unused*/) -> void * {
+    inited++;
+    return _cookie;
+  }
+  void arena_allocate_hook(const std::type_info * /*unused*/,
+                           uint64_t /*unused*/, void * /*unused*/) {
+    allocated++;
+  }
+  auto arena_destruction_hook(Arena * /*unused*/, void * /*unused*/,
+                              uint64_t /*unused*/, uint64_t /*unused*/)
+      -> void * {
+    destructed++;
+    return _cookie;
+  }
+  void arena_reset_hook(Arena * /*unused*/, void * /*unused*/,
+                        uint64_t /*unused*/, uint64_t /*unused*/) {
+    reseted++;
+  }
+  int inited = 0;
+  int allocated = 0;
+  int destructed = 0;
+  int reseted = 0;
 
-   private:
-    void* _cookie = nullptr;
+private:
+  void *_cookie = nullptr;
 };
 
-thread_local mock_hook* hook_instance;
+thread_local mock_hook *hook_instance;
 
-auto init_hook(Arena* a, [[maybe_unused]] const std::source_location& loc) -> void* {
-    return hook_instance->arena_init_hook(a);
+auto init_hook(Arena *a, [[maybe_unused]] const std::source_location &loc)
+    -> void * {
+  return hook_instance->arena_init_hook(a);
 }
 
-void allocate_hook(const std::type_info* t, uint64_t s, void* c) { hook_instance->arena_allocate_hook(t, s, c); }
-
-auto destruction_hook(Arena* a, void* c, uint64_t s, uint64_t w) -> void* {
-    return hook_instance->arena_destruction_hook(a, c, s, w);
+void allocate_hook(const std::type_info *t, uint64_t s, void *c) {
+  hook_instance->arena_allocate_hook(t, s, c);
 }
 
-void reset_hook(Arena* a, void* cookie, uint64_t space_used, uint64_t space_wasted) {
-    hook_instance->arena_reset_hook(a, cookie, space_used, space_wasted);
+auto destruction_hook(Arena *a, void *c, uint64_t s, uint64_t w) -> void * {
+  return hook_instance->arena_destruction_hook(a, c, s, w);
+}
+
+void reset_hook(Arena *a, void *cookie, uint64_t space_used,
+                uint64_t space_wasted) {
+  hook_instance->arena_reset_hook(a, cookie, space_used, space_wasted);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.HookTest") {
-    struct xx
-    {
-        int i;
-        char y;
-        double d;
-    };
+  struct xx {
+    int i;
+    char y;
+    double d;
+  };
 
-    void* cookie = std::malloc(128);
-    Arena::Options ops_hook = ops_complex;
-    ops_hook.on_arena_init = &init_hook;
-    ops_hook.on_arena_allocation = &allocate_hook;
-    ops_hook.on_arena_destruction = &destruction_hook;
-    ops_hook.on_arena_reset = &reset_hook;
-    mock = new alloc_class;
-    mock_cleaners = new cleanup_mock;
-    hook_instance = new mock_hook(cookie);
-    auto* a = new Arena(ops_hook);
-    ArenaTestHelper ah(*a);
-    CHECK_EQ(ah.cookie(), cookie);
-    auto* r = a->AllocateAligned(30);
-    CHECK_NE(r, nullptr);
-    CHECK_EQ(mock->alloc_sizes.front(), 4096);
-    CHECK_EQ(mock->alloc_sizes.size(), 1);
-    CHECK_EQ(hook_instance->allocated, 1);
+  void *cookie = std::malloc(128);
+  Arena::Options ops_hook = ops_complex;
+  ops_hook.on_arena_init = &init_hook;
+  ops_hook.on_arena_allocation = &allocate_hook;
+  ops_hook.on_arena_destruction = &destruction_hook;
+  ops_hook.on_arena_reset = &reset_hook;
+  mock = new alloc_class;
+  mock_cleaners = new cleanup_mock;
+  hook_instance = new mock_hook(cookie);
+  auto *a = new Arena(ops_hook);
+  ArenaTestHelper ah(*a);
+  CHECK_EQ(ah.cookie(), cookie);
+  auto r_result = a->AllocateAligned(30);
+  REQUIRE(r_result.has_value());
+  auto *r = r_result.value();
+  CHECK_NE(r, nullptr);
+  CHECK_EQ(mock->alloc_sizes.front(), 4096);
+  CHECK_EQ(mock->alloc_sizes.size(), 1);
+  CHECK_EQ(hook_instance->allocated, 1);
 
-    r = a->AllocateAligned(60);
-    CHECK_NE(r, nullptr);
-    CHECK_EQ(hook_instance->allocated, 2);
+  auto r2_result = a->AllocateAligned(60);
+  REQUIRE(r2_result.has_value());
+  CHECK_NE(r2_result.value(), nullptr);
+  CHECK_EQ(hook_instance->allocated, 2);
 
-    auto* rr = a->AllocateAlignedAndAddCleanup(150, &cleanup_mock_fn1, mock_cleaners);
-    CHECK_NE(rr, nullptr);
-    CHECK_EQ(hook_instance->allocated, 3);
+  auto rr_result =
+      a->AllocateAlignedAndAddCleanup(150, &cleanup_mock_fn1, mock_cleaners);
+  REQUIRE(rr_result.has_value());
+  auto *rr = rr_result.value();
+  CHECK_NE(rr, nullptr);
+  CHECK_EQ(hook_instance->allocated, 3);
 
-    auto* rrr = a->Create<xx>();
-    CHECK_NE(rrr, nullptr);
-    CHECK_EQ(hook_instance->allocated, 4);
+  auto rrr_result = a->Create<xx>();
+  REQUIRE(rrr_result.has_value());
+  auto *rrr = rrr_result.value();
+  CHECK_NE(rrr, nullptr);
+  CHECK_EQ(hook_instance->allocated, 4);
 
-    auto* rrrr = a->CreateArray<xx>(10);
-    CHECK_NE(rrrr, nullptr);
-    CHECK_EQ(hook_instance->allocated, 5);
+  auto rrrr_result = a->CreateArray<xx>(10);
+  REQUIRE(rrrr_result.has_value());
+  auto *rrrr = rrrr_result.value();
+  CHECK_NE(rrrr, nullptr);
+  CHECK_EQ(hook_instance->allocated, 5);
 
-    a->Reset();
-    CHECK(mock_cleaners->clean1);
-    CHECK_EQ(hook_instance->reseted, 1);
+  a->Reset();
+  CHECK(mock_cleaners->clean1);
+  CHECK_EQ(hook_instance->reseted, 1);
 
-    delete a;
-    CHECK_EQ(hook_instance->destructed, 1);
-    CHECK_EQ(mock->free_ptrs.size(), 1);
-    delete mock;
-    delete mock_cleaners;
-    delete hook_instance;
-    std::free(cookie);
+  delete a;
+  CHECK_EQ(hook_instance->destructed, 1);
+  CHECK_EQ(mock->free_ptrs.size(), 1);
+  delete mock;
+  delete mock_cleaners;
+  delete hook_instance;
+  std::free(cookie);
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.NullTest") {
-    mock_cleaners = new cleanup_mock;
-    mock = new alloc_fail_class;
-    cstr = new cstr_class;
-    cstr_class::count = 0;
+  mock_cleaners = new cleanup_mock;
+  mock = new alloc_fail_class;
+  cstr = new cstr_class;
+  cstr_class::count = 0;
 
-    auto* a = new Arena(ops_complex);
-    ArenaTestHelper ah(*a);
+  auto *a = new Arena(ops_complex);
+  ArenaTestHelper ah(*a);
 
-    auto* x = ah.newBlock(1024, nullptr);
-    CHECK_EQ(x, nullptr);
-    CHECK_EQ(ah.space_allocated(), 0ULL);
+  auto *x = ah.newBlock(1024, nullptr);
+  CHECK_EQ(x, nullptr);
+  CHECK_EQ(ah.space_allocated(), 0ULL);
 
-    char* y = a->AllocateAligned(1000);
-    CHECK_EQ(y, nullptr);
-    CHECK_EQ(ah.space_allocated(), 0ULL);
+  auto y_result = a->AllocateAligned(1000);
+  CHECK_FALSE(y_result.has_value());
+  CHECK_EQ(y_result.error(), ArenaError::AllocationFailed);
+  CHECK_EQ(ah.space_allocated(), 0ULL);
 
-    y = a->AllocateAlignedAndAddCleanup(1000, cleanup_mock_fn1, mock_cleaners);
-    CHECK_EQ(y, nullptr);
-    CHECK_EQ(ah.space_allocated(), 0ULL);
-    CHECK_EQ(a->cleanups(), 0ULL);
+  auto y2_result =
+      a->AllocateAlignedAndAddCleanup(1000, cleanup_mock_fn1, mock_cleaners);
+  CHECK_FALSE(y2_result.has_value());
+  CHECK_EQ(ah.space_allocated(), 0ULL);
+  CHECK_EQ(a->cleanups(), 0ULL);
 
-    std::string ss("hello world");
-    std::string sss("fuck the world");
-    CHECK_EQ(cstr->count, 0);
+  std::string ss("hello world");
+  std::string sss("fuck the world");
+  CHECK_EQ(cstr->count, 0);
 
-    auto* d2 = a->Create<mock_class_without_dstr>("fuck the world");
-    CHECK_EQ(a->cleanups(), 0ULL);
-    auto* d1 = a->Create<mock_class_need_dstr>(3, ss);
-    CHECK_EQ(a->cleanups(), 0ULL);
-    CHECK_EQ(d1, nullptr);
-    CHECK_EQ(d2, nullptr);
-    CHECK_EQ(ah.space_allocated(), 0ULL);
+  auto d2_result = a->Create<mock_class_without_dstr>("fuck the world");
+  CHECK_EQ(a->cleanups(), 0ULL);
+  auto d1_result = a->Create<mock_class_need_dstr>(3, ss);
+  CHECK_EQ(a->cleanups(), 0ULL);
+  CHECK_FALSE(d1_result.has_value());
+  CHECK_FALSE(d2_result.has_value());
+  CHECK_EQ(ah.space_allocated(), 0ULL);
 
-    auto* z = a->CreateArray<mock_struct>(100);
-    CHECK_EQ(z, nullptr);
-    CHECK_EQ(ah.space_allocated(), 0ULL);
-    CHECK_EQ(a->cleanups(), 0ULL);
+  auto z_result = a->CreateArray<mock_struct>(100);
+  CHECK_FALSE(z_result.has_value());
+  CHECK_EQ(ah.space_allocated(), 0ULL);
+  CHECK_EQ(a->cleanups(), 0ULL);
 
-    delete mock_cleaners;
-    delete mock;
-    delete cstr;
-    delete a;
+  delete mock_cleaners;
+  delete mock;
+  delete cstr;
+  delete a;
 }
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.MemoryResourceTest") {
-    mock = new alloc_class;
+  mock = new alloc_class;
 
-    Arena::Options opts = Arena::Options::GetDefaultOptions();
-    opts.normal_block_size = 256;
-    opts.huge_block_size = 512;
-    opts.suggested_init_block_size = 256;
-    opts.block_alloc = &mock_alloc;
-    opts.block_dealloc = &mock_dealloc;
+  Arena::Options opts = Arena::Options::GetDefaultOptions();
+  opts.normal_block_size = 256;
+  opts.huge_block_size = 512;
+  opts.suggested_init_block_size = 256;
+  opts.block_alloc = &mock_alloc;
+  opts.block_dealloc = &mock_dealloc;
 
-    auto* arena = new Arena{opts};
-    Arena::memory_resource res{arena};
+  auto *arena = new Arena{opts};
+  Arena::memory_resource res{arena};
 
-    // char mem[256];
+  // char mem[256];
 
-    // get_arena
-    CHECK_EQ(arena, res.get_arena());
+  // get_arena
+  CHECK_EQ(arena, res.get_arena());
 
-    // allocate
-    // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem)));
-    void* ptr = res.allocate(128);
-    char* address = static_cast<char*>(mock->ptrs.front());
-    CHECK_EQ(ptr, address + kBlockHeaderSize);
-    void* ptr2 = res.allocate(32);
-    CHECK_EQ(mock->ptrs.size(), 1);
+  // allocate
+  // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem)));
+  void *ptr = res.allocate(128);
+  char *address = static_cast<char *>(mock->ptrs.front());
+  CHECK_EQ(ptr, address + kBlockHeaderSize);
+  void *ptr2 = res.allocate(32);
+  CHECK_EQ(mock->ptrs.size(), 1);
 
-    // deallocate
-    res.deallocate(ptr2, 32);
-    res.deallocate(ptr, 128);
+  // deallocate
+  res.deallocate(ptr2, 32);
+  res.deallocate(ptr, 128);
 
-    SUBCASE("ptr ==") {
-        auto* memory_resource_ptr1 = arena->get_memory_resource();
-        auto* memory_resource_ptr2 = arena->get_memory_resource();
-        CHECK_NE(memory_resource_ptr1, nullptr);
-        CHECK_EQ(memory_resource_ptr1, memory_resource_ptr2);
-    }
-    // operator==
-    SUBCASE("operator ==") {
-        Arena::memory_resource& res2 = res;
-        CHECK_EQ(res, res2);  // NOLINT
+  SUBCASE("ptr ==") {
+    auto *memory_resource_ptr1 = arena->get_memory_resource();
+    auto *memory_resource_ptr2 = arena->get_memory_resource();
+    CHECK_NE(memory_resource_ptr1, nullptr);
+    CHECK_EQ(memory_resource_ptr1, memory_resource_ptr2);
+  }
+  // operator==
+  SUBCASE("operator ==") {
+    Arena::memory_resource &res2 = res;
+    CHECK_EQ(res, res2); // NOLINT
 
-        Arena::memory_resource res3 = *arena->get_memory_resource();
-        CHECK_EQ(res, res3);  // NOLINT
-    }
-    SUBCASE("operator !=") {
-        Arena arena2{opts};
-        auto res2 = *arena2.get_memory_resource();
-        CHECK_NE(res, res2);  // NOLINT
+    Arena::memory_resource res3 = *arena->get_memory_resource();
+    CHECK_EQ(res, res3); // NOLINT
+  }
+  SUBCASE("operator !=") {
+    Arena arena2{opts};
+    auto res2 = *arena2.get_memory_resource();
+    CHECK_NE(res, res2); // NOLINT
 
 #ifndef __APPLE__
-        auto res3 = pmr::monotonic_buffer_resource{};
-        CHECK_NE(res2, res3);  // NOLINT
+    auto res3 = pmr::monotonic_buffer_resource{};
+    CHECK_NE(res2, res3); // NOLINT
 #endif
-    }
+  }
 
-    delete arena;
-    CHECK_EQ(mock->free_ptrs.size(), 1);
-    delete mock;
-    mock = nullptr;
+  delete arena;
+  CHECK_EQ(mock->free_ptrs.size(), 1);
+  delete mock;
+  mock = nullptr;
 }
 
-class Foo
-{
-    using allocator_type = pmr::polymorphic_allocator<Foo>;
+class Foo {
+  using allocator_type = pmr::polymorphic_allocator<Foo>;
 
-   public:
-    explicit Foo(allocator_type alloc) : allocator_(alloc), vec_{alloc} {};
-    Foo(const Foo& foo, allocator_type alloc) : allocator_(alloc), vec_{foo.vec_, alloc} {};
-    Foo(Foo&& foo) noexcept : Foo{std::move(foo), foo.allocator_} {};
-    // NOLINTNEXTLINE
-    Foo(Foo&& foo, allocator_type alloc) : allocator_(alloc), vec_(alloc) { vec_ = std::move(foo.vec_); }
+public:
+  explicit Foo(allocator_type alloc) : allocator_(alloc), vec_{alloc} {};
+  Foo(const Foo &foo, allocator_type alloc)
+      : allocator_(alloc), vec_{foo.vec_, alloc} {};
+  Foo(Foo &&foo) noexcept : Foo{std::move(foo), foo.allocator_} {};
+  // NOLINTNEXTLINE
+  Foo(Foo &&foo, allocator_type alloc) : allocator_(alloc), vec_(alloc) {
+    vec_ = std::move(foo.vec_);
+  }
 
-    allocator_type allocator_;
-    pmr::vector<int> vec_;
+  allocator_type allocator_;
+  pmr::vector<int> vec_;
 };
 
 TEST_CASE_FIXTURE(ArenaTest, "ArenaTest.AllocatorAwareTest") {
-    Arena::Options opts = Arena::Options::GetDefaultOptions();
-    opts.normal_block_size = 256;
-    opts.huge_block_size = 512;
-    opts.suggested_init_block_size = 256;
-    opts.block_alloc = &mock_alloc;
-    opts.block_dealloc = &mock_dealloc;
+  Arena::Options opts = Arena::Options::GetDefaultOptions();
+  opts.normal_block_size = 256;
+  opts.huge_block_size = 512;
+  opts.suggested_init_block_size = 256;
+  opts.block_alloc = &mock_alloc;
+  opts.block_dealloc = &mock_dealloc;
 
-    SUBCASE("CTOR") {  // ctor
-        // char mem[256];
-        mock = new alloc_class;
-        auto* arena = new Arena(opts);
-        Arena::memory_resource res{arena};
-        Foo foo(&res);
-        ArenaTestHelper ah(*arena);
+  SUBCASE("CTOR") { // ctor
+    // char mem[256];
+    mock = new alloc_class;
+    auto *arena = new Arena(opts);
+    Arena::memory_resource res{arena};
+    Foo foo(&res);
+    ArenaTestHelper ah(*arena);
 
-        // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem)));
-        // EXPECT_CALL(*mock, dealloc(std::data(mem))).Times(1);
+    // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem)));
+    // EXPECT_CALL(*mock, dealloc(std::data(mem))).Times(1);
 
-        foo.vec_.resize(2);
-        CHECK_EQ(256 - 8 - kBlockHeaderSize, ah.last_block()->remain());
-        foo.vec_.resize(1);
-        CHECK_EQ(256 - 8 - kBlockHeaderSize, ah.last_block()->remain());
-        foo.vec_.resize(4);
-        CHECK_EQ(256 - 8 - 16 - kBlockHeaderSize, ah.last_block()->remain());
+    foo.vec_.resize(2);
+    CHECK_EQ(256 - 8 - kBlockHeaderSize, ah.last_block()->remain());
+    foo.vec_.resize(1);
+    CHECK_EQ(256 - 8 - kBlockHeaderSize, ah.last_block()->remain());
+    foo.vec_.resize(4);
+    CHECK_EQ(256 - 8 - 16 - kBlockHeaderSize, ah.last_block()->remain());
 
-        delete arena;
-        CHECK_EQ(mock->ptrs.size(), 1);
-        CHECK_EQ(mock->free_ptrs.size(), 1);
-        CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
-        CHECK_EQ(mock->alloc_sizes.front(), 256);
-        delete mock;
-        mock = nullptr;
-    }
+    delete arena;
+    CHECK_EQ(mock->ptrs.size(), 1);
+    CHECK_EQ(mock->free_ptrs.size(), 1);
+    CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
+    CHECK_EQ(mock->alloc_sizes.front(), 256);
+    delete mock;
+    mock = nullptr;
+  }
 
-    SUBCASE("COPY") {  // copy
-        // char mem1[256];
-        mock = new alloc_class;
-        auto* arena1 = new Arena(opts);
-        Arena::memory_resource res1{arena1};
-        ArenaTestHelper ah(*arena1);
-        // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem1)));
-        // EXPECT_CALL(*mock, dealloc(std::data(mem1))).Times(1);
+  SUBCASE("COPY") { // copy
+    // char mem1[256];
+    mock = new alloc_class;
+    auto *arena1 = new Arena(opts);
+    Arena::memory_resource res1{arena1};
+    ArenaTestHelper ah(*arena1);
+    // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem1)));
+    // EXPECT_CALL(*mock, dealloc(std::data(mem1))).Times(1);
 
-        Foo foo1(&res1);
-        foo1.vec_ = {1, 2, 3, 4};
-        CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
+    Foo foo1(&res1);
+    foo1.vec_ = {1, 2, 3, 4};
+    CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
 
-        // copy with same arena
-        Foo foo2(foo1, &res1);
-        foo2.vec_[3] = 5;
-        CHECK_EQ(256 - 16 - 16 - kBlockHeaderSize, ah.last_block()->remain());
-        CHECK_EQ(0, memcmp(foo1.vec_.data(), foo2.vec_.data(), 4));
+    // copy with same arena
+    Foo foo2(foo1, &res1);
+    foo2.vec_[3] = 5;
+    CHECK_EQ(256 - 16 - 16 - kBlockHeaderSize, ah.last_block()->remain());
+    CHECK_EQ(0, memcmp(foo1.vec_.data(), foo2.vec_.data(), 4));
 
-        // CHECK_EQ(foo1.vec_.data(), reinterpret_cast<int*>(mock->ptrs.front() + kBlockHeaderSize));
-        CHECK_EQ(foo1.vec_.data() + 4, foo2.vec_.data());
-        delete arena1;
-        CHECK_EQ(mock->ptrs.size(), 1);
-        CHECK_EQ(mock->free_ptrs.size(), 1);
-        CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
-        CHECK_EQ(mock->alloc_sizes.front(), 256);
+    // CHECK_EQ(foo1.vec_.data(), reinterpret_cast<int*>(mock->ptrs.front() +
+    // kBlockHeaderSize));
+    CHECK_EQ(foo1.vec_.data() + 4, foo2.vec_.data());
+    delete arena1;
+    CHECK_EQ(mock->ptrs.size(), 1);
+    CHECK_EQ(mock->free_ptrs.size(), 1);
+    CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
+    CHECK_EQ(mock->alloc_sizes.front(), 256);
 
-        mock->reset();
-        // copy with another arena
-        auto* arena2 = new Arena(opts);
-        Arena::memory_resource res2{arena2};
-        ArenaTestHelper ah2(*arena2);
-        // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem2)));
-        // EXPECT_CALL(*mock, dealloc(std::data(mem2))).Times(1);
+    mock->reset();
+    // copy with another arena
+    auto *arena2 = new Arena(opts);
+    Arena::memory_resource res2{arena2};
+    ArenaTestHelper ah2(*arena2);
+    // EXPECT_CALL(*mock, alloc(256)).WillOnce(Return(std::data(mem2)));
+    // EXPECT_CALL(*mock, dealloc(std::data(mem2))).Times(1);
 
-        Foo foo3(foo2, &res2);
-        foo3.vec_[0] = 6;
-        CHECK_EQ(256 - 16 - kBlockHeaderSize, ah2.last_block()->remain());
-        CHECK_EQ(foo3.vec_[0], 6);
-        CHECK_EQ(foo3.vec_[1], 2);
-        CHECK_EQ(foo3.vec_[2], 3);
-        CHECK_EQ(foo3.vec_[3], 5);
-        delete arena2;
-        // EXPECT_THAT(foo3.vec_, ElementsAre(6, 2, 3, 5));
-        CHECK_EQ(mock->ptrs.size(), 1);
-        CHECK_EQ(mock->free_ptrs.size(), 1);
-        CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
-        CHECK_EQ(mock->alloc_sizes.front(), 256);
-        delete mock;
-        mock = nullptr;
-    }
+    Foo foo3(foo2, &res2);
+    foo3.vec_[0] = 6;
+    CHECK_EQ(256 - 16 - kBlockHeaderSize, ah2.last_block()->remain());
+    CHECK_EQ(foo3.vec_[0], 6);
+    CHECK_EQ(foo3.vec_[1], 2);
+    CHECK_EQ(foo3.vec_[2], 3);
+    CHECK_EQ(foo3.vec_[3], 5);
+    delete arena2;
+    // EXPECT_THAT(foo3.vec_, ElementsAre(6, 2, 3, 5));
+    CHECK_EQ(mock->ptrs.size(), 1);
+    CHECK_EQ(mock->free_ptrs.size(), 1);
+    CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
+    CHECK_EQ(mock->alloc_sizes.front(), 256);
+    delete mock;
+    mock = nullptr;
+  }
 
-    SUBCASE("MOVE") {  // move
-        // char mem1[256];
-        mock = new alloc_class;
-        auto* arena1 = new Arena(opts);
-        Arena::memory_resource res1{arena1};
-        ArenaTestHelper ah(*arena1);
+  SUBCASE("MOVE") { // move
+    // char mem1[256];
+    mock = new alloc_class;
+    auto *arena1 = new Arena(opts);
+    Arena::memory_resource res1{arena1};
+    ArenaTestHelper ah(*arena1);
 
-        // move with same arena
-        Foo foo1(&res1);
-        foo1.vec_ = {1, 2, 3, 4};
-        CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
+    // move with same arena
+    Foo foo1(&res1);
+    foo1.vec_ = {1, 2, 3, 4};
+    CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
 
-        Foo foo2(std::move(foo1));
-        CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
-        // NOLINTNEXTLINE
-        CHECK_EQ(0, foo1.vec_.size());
-        CHECK_EQ(4, foo2.vec_.size());
+    Foo foo2(std::move(foo1));
+    CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
+    // NOLINTNEXTLINE
+    CHECK_EQ(0, foo1.vec_.size());
+    CHECK_EQ(4, foo2.vec_.size());
 
-        Foo foo3(std::move(foo2), &res1);
-        CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
-        // NOLINTNEXTLINE
-        CHECK_EQ(0, foo2.vec_.size());
-        CHECK_EQ(4, foo3.vec_.size());
-        delete arena1;
-        CHECK_EQ(mock->ptrs.size(), 1);
-        CHECK_EQ(mock->free_ptrs.size(), 1);
-        CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
-        CHECK_EQ(mock->alloc_sizes.front(), 256);
+    Foo foo3(std::move(foo2), &res1);
+    CHECK_EQ(256 - 16 - kBlockHeaderSize, ah.last_block()->remain());
+    // NOLINTNEXTLINE
+    CHECK_EQ(0, foo2.vec_.size());
+    CHECK_EQ(4, foo3.vec_.size());
+    delete arena1;
+    CHECK_EQ(mock->ptrs.size(), 1);
+    CHECK_EQ(mock->free_ptrs.size(), 1);
+    CHECK_EQ(mock->ptrs.front(), mock->free_ptrs.front());
+    CHECK_EQ(mock->alloc_sizes.front(), 256);
 
-        delete mock;
-        mock = nullptr;
-    }
+    delete mock;
+    mock = nullptr;
+  }
 }
 
 TEST_CASE("ArenaTest.pmr-support") {
-    auto options = Arena::Options::GetDefaultOptions();
-    Arena arena(options);
-    SUBCASE("String") {
-        pmr::string str("stringstringstring..............213423423443242344", arena.get_memory_resource());
-        CHECK_EQ(arena.check(str.c_str()), ArenaContainStatus::BlockUsed);
-    }
-    SUBCASE("vector") {
-        pmr::vector<pmr::string> strings(arena.get_memory_resource());
-        strings.emplace_back(pmr::string("123123123_+23423432423agsagasb+234324b1321312bsafs........a2423",
-                                         arena.get_memory_resource()));  // NOLINT(modernize-use-emplace)
-        CHECK_EQ(strings.size(), 1);
-        CHECK_EQ(arena.check(strings.front().c_str()), ArenaContainStatus::BlockUsed);
-    }
+  auto options = Arena::Options::GetDefaultOptions();
+  Arena arena(options);
+  SUBCASE("String") {
+    pmr::string str("stringstringstring..............213423423443242344",
+                    arena.get_memory_resource());
+    CHECK_EQ(arena.check(str.c_str()), ArenaContainStatus::BlockUsed);
+  }
+  SUBCASE("vector") {
+    pmr::vector<pmr::string> strings(arena.get_memory_resource());
+    strings.emplace_back(pmr::string(
+        "123123123_+23423432423agsagasb+234324b1321312bsafs........a2423",
+        arena.get_memory_resource())); // NOLINT(modernize-use-emplace)
+    CHECK_EQ(strings.size(), 1);
+    CHECK_EQ(arena.check(strings.front().c_str()),
+             ArenaContainStatus::BlockUsed);
+  }
 }
 
 TEST_CASE("ArenaTest.Create-support-pmr") {
-    auto options = Arena::Options::GetDefaultOptions();
-    Arena arena(options);
-    SUBCASE("String") {
-        auto* pmr_str = arena.Create<pmr::string>("safsdaf_sadgsadf21321300000");
-        CHECK_EQ(arena.check(pmr_str->c_str()), ArenaContainStatus::BlockUsed);
-    }
+  auto options = Arena::Options::GetDefaultOptions();
+  Arena arena(options);
+  SUBCASE("String") {
+    auto pmr_str_result =
+        arena.Create<pmr::string>("safsdaf_sadgsadf21321300000");
+    REQUIRE(pmr_str_result.has_value());
+    auto *pmr_str = pmr_str_result.value();
+    CHECK_EQ(arena.check(pmr_str->c_str()), ArenaContainStatus::BlockUsed);
+  }
 
-    SUBCASE("vector-emplace") {
-        auto* strings = arena.Create<pmr::vector<pmr::string>>();
-        strings->emplace_back("123123123_+23423432423agsagasb+234324b1321312bsafs........a2423");
-        CHECK_EQ(strings->size(), 1);
-        CHECK_EQ(arena.check(strings->front().c_str()), ArenaContainStatus::BlockUsed);
-    }
+  SUBCASE("vector-emplace") {
+    auto strings_result = arena.Create<pmr::vector<pmr::string>>();
+    REQUIRE(strings_result.has_value());
+    auto *strings = strings_result.value();
+    strings->emplace_back(
+        "123123123_+23423432423agsagasb+234324b1321312bsafs........a2423");
+    CHECK_EQ(strings->size(), 1);
+    CHECK_EQ(arena.check(strings->front().c_str()),
+             ArenaContainStatus::BlockUsed);
+  }
 
-    SUBCASE("vector-push") {
-        auto* strings = arena.Create<pmr::vector<pmr::string>>();
-        auto* pmr_str = arena.Create<pmr::string>("safsdaf_sadgsadf21321300000");
-        strings->push_back(*pmr_str);
-        CHECK_EQ(strings->size(), 1);
-        CHECK_EQ(arena.check(strings->front().c_str()), ArenaContainStatus::BlockUsed);
-        CHECK_NE(pmr_str->c_str(), strings->front().c_str());
-    }
+  SUBCASE("vector-push") {
+    auto strings_result = arena.Create<pmr::vector<pmr::string>>();
+    REQUIRE(strings_result.has_value());
+    auto *strings = strings_result.value();
+    auto pmr_str_result =
+        arena.Create<pmr::string>("safsdaf_sadgsadf21321300000");
+    REQUIRE(pmr_str_result.has_value());
+    auto *pmr_str = pmr_str_result.value();
+    strings->push_back(*pmr_str);
+    CHECK_EQ(strings->size(), 1);
+    CHECK_EQ(arena.check(strings->front().c_str()),
+             ArenaContainStatus::BlockUsed);
+    CHECK_NE(pmr_str->c_str(), strings->front().c_str());
+  }
 }
-struct class_with_allocator
-{
-    using allocator_type = pmr::polymorphic_allocator<char>;
-    pmr::string name;
-    explicit class_with_allocator(allocator_type alloc = {}) : name(alloc) {}
+struct class_with_allocator {
+  using allocator_type = pmr::polymorphic_allocator<char>;
+  pmr::string name;
+  explicit class_with_allocator(allocator_type alloc = {}) : name(alloc) {}
 };
 
 TEST_CASE("ArenaTest.Create_Object_with_allocator") {
-    auto options = Arena::Options::GetDefaultOptions();
-    Arena a(options);
-    auto* obj = a.Create<class_with_allocator>();
-    CHECK_EQ(a.check(obj->name.c_str()), ArenaContainStatus::BlockUsed);
+  auto options = Arena::Options::GetDefaultOptions();
+  Arena a(options);
+  auto obj_result = a.Create<class_with_allocator>();
+  REQUIRE(obj_result.has_value());
+  auto *obj = obj_result.value();
+  CHECK_EQ(a.check(obj->name.c_str()), ArenaContainStatus::BlockUsed);
 }
 
-struct simple_test_struct
-{
-    int _s;
+struct simple_test_struct {
+  int _s;
 };
 
-struct simple_test_struct_with_tag
-{
-    int _s;
-    ArenaFullManagedTag;
+struct simple_test_struct_with_tag {
+  int _s;
+  ArenaFullManagedTag;
 };
 
 TEST_CASE("ArenaTagOverhead") {
-    CHECK_EQ(sizeof(simple_test_struct), 4);
-    CHECK_EQ(sizeof(simple_test_struct_with_tag), 4);
+  CHECK_EQ(sizeof(simple_test_struct), 4);
+  CHECK_EQ(sizeof(simple_test_struct_with_tag), 4);
 }
-
 
 /*
 TEST_CASE("ArenaTest.MoveAssignmentTest") {
@@ -1369,14 +1475,12 @@ TEST_CASE("ArenaTest.MoveAssignmentTest") {
 }
  */
 #if defined(__amd64__)
-struct int256_t
-{
-    __m256i val;
+struct int256_t {
+  __m256i val;
 };
 #else
-struct int256_t
-{
-    int64_t val[4];
+struct int256_t {
+  int64_t val[4];
 };
 #endif
 
@@ -1388,47 +1492,45 @@ using int128_t = __int128_t;
  * @warning make sure the sanitizer don't generate any error
  */
 TEST_CASE_TEMPLATE("arena::pmr", T, TYPES) {
-    Arena arena{Arena::Options::GetDefaultOptions()};
+  Arena arena{Arena::Options::GetDefaultOptions()};
 
-    {
-        auto* resource = arena.get_memory_resource();
-        std::pmr::vector<T> vec(resource);
-        vec.reserve(64);
-    }
+  {
+    auto *resource = arena.get_memory_resource();
+    std::pmr::vector<T> vec(resource);
+    vec.reserve(64);
+  }
 
-    // align 8 bytes
-    (void)arena.Create<bool>(false);
+  // align 8 bytes
+  (void)arena.Create<bool>(false);
 
-    auto* resource = arena.get_memory_resource();
-    pmr::vector<T> vec(resource);
-    vec.reserve(3);
+  auto *resource = arena.get_memory_resource();
+  pmr::vector<T> vec(resource);
+  vec.reserve(3);
 
-    vec.emplace_back();
-    vec.emplace_back();
-    vec.emplace_back();
+  vec.emplace_back();
+  vec.emplace_back();
+  vec.emplace_back();
 
-    // access the vector to check alignment
-    // for (const auto val : vec) {
-    //     std::print("=== val : {}\n", sizeof(val));
-    // }
+  // access the vector to check alignment
+  // for (const auto val : vec) {
+  //     std::print("=== val : {}\n", sizeof(val));
+  // }
 }
 
-}  // namespace arena
+} // namespace arena
 
 namespace arena {
-struct arena_managed_struct
-{
-    using ArenaManaged_ = void;
+struct arena_managed_struct {
+  using ArenaManaged_ = void;
 };
 
-struct arena_non_managed_struct
-{};
+struct arena_non_managed_struct {};
 
 TEST_CASE("ArenaHelper") {
-    static_assert(is_arena_full_managable<arena_managed_struct>::value,
-                  "arena_managed_struct should have full managed tag");
-    static_assert(not is_arena_full_managable<arena_non_managed_struct>::value,
-                  "arena_managed_struct should not have full managed tag");
+  static_assert(is_arena_full_managable<arena_managed_struct>::value,
+                "arena_managed_struct should have full managed tag");
+  static_assert(not is_arena_full_managable<arena_non_managed_struct>::value,
+                "arena_managed_struct should not have full managed tag");
 }
 
-}  // namespace arena
+} // namespace arena

--- a/tests/metrics_test.cc
+++ b/tests/metrics_test.cc
@@ -15,201 +15,202 @@
  */
 #include "arena/metrics.hpp"
 
-#include <cstdlib>  // for free, malloc
-#include <thread>   // for thread
+#include <cstdlib> // for free, malloc
+#include <thread>  // for thread
 
-#include "arena/arena.hpp"    // for Arena, Arena::Options
-#include "doctest/doctest.h"  // for binary_assert, CHECK_EQ, TestCase, CHECK
+#include "arena/arena.hpp"   // for Arena, Arena::Options
+#include "doctest/doctest.h" // for binary_assert, CHECK_EQ, TestCase, CHECK
 
 namespace arena {
 
+class ThreadLocalArenaMetricsTest {
+protected:
+  Arena::Options ops;
+  // NOLINTNEXTLINE
+  static auto alloc(std::size_t size) -> void * { return std::malloc(size); }
+  // NOLINTNEXTLINE
+  static void dealloc(void *ptr) { std::free(ptr); }
 
-class ThreadLocalArenaMetricsTest
-{
-   protected:
-    Arena::Options ops;
-    // NOLINTNEXTLINE
-    static auto alloc(std::size_t size) -> void* { return std::malloc(size); }
-    // NOLINTNEXTLINE
-    static void dealloc(void* ptr) { std::free(ptr); }
+  ThreadLocalArenaMetricsTest() {
+    ops.block_alloc = &alloc;
+    ops.block_dealloc = &dealloc;
+    ops.normal_block_size = 1024ULL;
+    ops.suggested_init_block_size = 1024ULL;
+    ops.huge_block_size = 1024ULL;
 
-    ThreadLocalArenaMetricsTest() {
-        ops.block_alloc = &alloc;
-        ops.block_dealloc = &dealloc;
-        ops.normal_block_size = 1024ULL;
-        ops.suggested_init_block_size = 1024ULL;
-        ops.huge_block_size = 1024ULL;
+    ops.on_arena_init = &metrics_probe_on_arena_init;
+    ops.on_arena_reset = &metrics_probe_on_arena_reset;
+    ops.on_arena_allocation = &metrics_probe_on_arena_allocation;
+    ops.on_arena_newblock = &metrics_probe_on_arena_newblock;
+    ops.on_arena_destruction = &metrics_probe_on_arena_destruction;
+  };
 
-        ops.on_arena_init = &metrics_probe_on_arena_init;
-        ops.on_arena_reset = &metrics_probe_on_arena_reset;
-        ops.on_arena_allocation = &metrics_probe_on_arena_allocation;
-        ops.on_arena_newblock = &metrics_probe_on_arena_newblock;
-        ops.on_arena_destruction = &metrics_probe_on_arena_destruction;
-    };
-
-    ~ThreadLocalArenaMetricsTest() {
-        local_arena_metrics.reset();
-        global_arena_metrics.reset();
-    };
+  ~ThreadLocalArenaMetricsTest() {
+    local_arena_metrics.reset();
+    global_arena_metrics.reset();
+  };
 };
 
 TEST_CASE_FIXTURE(ThreadLocalArenaMetricsTest, "MetricsInit") {
-    auto* a = new Arena(ops);
-    delete a;
-    auto& m = local_arena_metrics;
-    CHECK_EQ(m.init_count, 1);
+  auto *a = new Arena(ops);
+  delete a;
+  auto &m = local_arena_metrics;
+  CHECK_EQ(m.init_count, 1);
 }
 
 TEST_CASE_FIXTURE(ThreadLocalArenaMetricsTest, "MetricsReset") {
-    auto* a = new Arena(ops);
-    auto* _ = a->AllocateAligned(124);
-    a->Reset();
-    delete a;
-    auto& m = local_arena_metrics;
-    CHECK(_);
-    CHECK_EQ(m.reset_count, 1);
-    CHECK_EQ(m.space_allocated, 124);
+  auto *a = new Arena(ops);
+  auto result = a->AllocateAligned(124);
+  REQUIRE(result.has_value());
+  a->Reset();
+  delete a;
+  auto &m = local_arena_metrics;
+  CHECK(result.value() != nullptr);
+  CHECK_EQ(m.reset_count, 1);
+  CHECK_EQ(m.space_allocated, 124);
 }
 
 TEST_CASE_FIXTURE(ThreadLocalArenaMetricsTest, "MetricsAllocation") {
-    {
-        auto* a = new Arena(ops);
-        auto* _ = a->AllocateAligned(10);
-        delete a;
-        auto& m = local_arena_metrics;
-        CHECK(_);
-        CHECK_EQ(m.alloc_count, 1);
-        CHECK_EQ(m.space_allocated, 10);
-    }
+  {
+    auto *a = new Arena(ops);
+    auto result = a->AllocateAligned(10);
+    delete a;
+    auto &m = local_arena_metrics;
+    CHECK(result.has_value());
+    CHECK_EQ(m.alloc_count, 1);
+    CHECK_EQ(m.space_allocated, 10);
+  }
 
-    {
-        auto* a = new Arena(ops);
-        auto* _ = a->AllocateAligned(100);
-        delete a;
-        auto& m = local_arena_metrics;
-        CHECK(_);
-        CHECK_EQ(m.alloc_count, 2);
-        CHECK_EQ(m.alloc_size_bucket_counter[0], 1);
-        CHECK_EQ(m.alloc_size_bucket_counter[1], 1);
-        CHECK_EQ(m.space_allocated, 110);
-    }
+  {
+    auto *a = new Arena(ops);
+    auto result = a->AllocateAligned(100);
+    delete a;
+    auto &m = local_arena_metrics;
+    CHECK(result.has_value());
+    CHECK_EQ(m.alloc_count, 2);
+    CHECK_EQ(m.alloc_size_bucket_counter[0], 1);
+    CHECK_EQ(m.alloc_size_bucket_counter[1], 1);
+    CHECK_EQ(m.space_allocated, 110);
+  }
 }
 
 TEST_CASE_FIXTURE(ThreadLocalArenaMetricsTest, "MetricsNewBlock") {
-    SUBCASE("reuse block") {  // reuse block
-        auto* a = new Arena(ops);
-        auto* p1 = a->AllocateAligned(10);
-        auto* p2 = a->AllocateAligned(100);
-        delete a;
-        auto& m = local_arena_metrics;
-        CHECK(p1 != nullptr);
-        CHECK(p2 != nullptr);
-        CHECK_EQ(m.alloc_count, 2);
-        CHECK_EQ(m.newblock_count, 1);
-    }
+  SUBCASE("reuse block") { // reuse block
+    auto *a = new Arena(ops);
+    auto p1 = a->AllocateAligned(10);
+    auto p2 = a->AllocateAligned(100);
+    delete a;
+    auto &m = local_arena_metrics;
+    CHECK(p1.has_value());
+    CHECK(p2.has_value());
+    CHECK_EQ(m.alloc_count, 2);
+    CHECK_EQ(m.newblock_count, 1);
+  }
 
-    local_arena_metrics.reset();
+  local_arena_metrics.reset();
 
-    SUBCASE("non-fully reuse block lead to space waste") {  // non-fully reuse block lead to space_waste
-        auto* a = new Arena(ops);
-        auto* p1 = a->AllocateAligned(10);
-        auto* p2 = a->AllocateAligned(65535);
-        delete a;
-        auto& m = local_arena_metrics;
-        CHECK(p1 != nullptr);
-        CHECK(p2 != nullptr);
-        CHECK_EQ(m.alloc_count, 2);
-        CHECK_EQ(m.newblock_count, 2);
-        CHECK_GT(m.space_wasted, 0);
-    }
+  SUBCASE(
+      "non-fully reuse block lead to space waste") { // non-fully reuse block
+                                                     // lead to space_waste
+    auto *a = new Arena(ops);
+    auto p1 = a->AllocateAligned(10);
+    auto p2 = a->AllocateAligned(65535);
+    delete a;
+    auto &m = local_arena_metrics;
+    CHECK(p1.has_value());
+    CHECK(p2.has_value());
+    CHECK_EQ(m.alloc_count, 2);
+    CHECK_EQ(m.newblock_count, 2);
+    CHECK_GT(m.space_wasted, 0);
+  }
 }
 
 TEST_CASE_FIXTURE(ThreadLocalArenaMetricsTest, "MetricsDestruction") {
-    auto* a = new Arena(ops);
-    auto* _ = a->AllocateAligned(10);
-    delete a;
-    CHECK(_);
-    auto& m = local_arena_metrics;
-    CHECK_EQ(m.destruct_count, 1);
+  auto *a = new Arena(ops);
+  auto result = a->AllocateAligned(10);
+  delete a;
+  CHECK(result.has_value());
+  auto &m = local_arena_metrics;
+  CHECK_EQ(m.destruct_count, 1);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE_FIXTURE(ThreadLocalArenaMetricsTest, "MetricsReportToGlobalMetrics") {
-    auto* a = new Arena(ops);
-    uint64_t alloc_count = 1024;
-    for (uint64_t i = 0; i < alloc_count; i++) {
-        auto* _ = a->AllocateAligned(10 * i);
-        CHECK(_);
-    }
-    delete a;
+  auto *a = new Arena(ops);
+  uint64_t alloc_count = 1024;
+  for (uint64_t i = 0; i < alloc_count; i++) {
+    auto result = a->AllocateAligned(10 * i);
+    CHECK(result.has_value());
+  }
+  delete a;
 
-    {
-        auto& global = global_arena_metrics;
-        CHECK_EQ(global.init_count, 0);
-        CHECK_EQ(global.alloc_count, 0);
-        CHECK_EQ(global.destruct_count, 0);
-        auto& m = local_arena_metrics;
-        CHECK_EQ(m.init_count, 1);
-        CHECK_EQ(m.alloc_count, alloc_count);
-        CHECK_EQ(m.destruct_count, 1);
-    }
+  {
+    auto &global = global_arena_metrics;
+    CHECK_EQ(global.init_count, 0);
+    CHECK_EQ(global.alloc_count, 0);
+    CHECK_EQ(global.destruct_count, 0);
+    auto &m = local_arena_metrics;
+    CHECK_EQ(m.init_count, 1);
+    CHECK_EQ(m.alloc_count, alloc_count);
+    CHECK_EQ(m.destruct_count, 1);
+  }
 
-    {
-        local_arena_metrics.report_to_global_metrics();
-        auto& global = global_arena_metrics;
-        CHECK_EQ(global.init_count, 1);
-        CHECK_EQ(global.alloc_count, alloc_count);
-        CHECK_EQ(global.destruct_count, 1);
+  {
+    local_arena_metrics.report_to_global_metrics();
+    auto &global = global_arena_metrics;
+    CHECK_EQ(global.init_count, 1);
+    CHECK_EQ(global.alloc_count, alloc_count);
+    CHECK_EQ(global.destruct_count, 1);
 
-        auto& m = local_arena_metrics;
-        CHECK_EQ(m.init_count, 0);
-        CHECK_EQ(m.alloc_count, 0);
-        CHECK_EQ(m.destruct_count, 0);
+    auto &m = local_arena_metrics;
+    CHECK_EQ(m.init_count, 0);
+    CHECK_EQ(m.alloc_count, 0);
+    CHECK_EQ(m.destruct_count, 0);
 
-        global.reset();
-    }
+    global.reset();
+  }
 
-    {  // multi-thread
-        bool alloc_success1 = false;
-        auto f1 = [=, this, &alloc_success1]() {
-            // g_cs = *cs;
-            auto* aa = new Arena(ops);
-            uint64_t alloc_count_ = 1024;
-            for (uint64_t i = 0; i < alloc_count_; i++) {
-                alloc_success1 = (aa->AllocateAligned(10 * i) != nullptr);
-            }
-            delete aa;
-            local_arena_metrics.report_to_global_metrics();
-        };
-        bool alloc_success2 = false;
-        auto f2 = [=, this, &alloc_success2]() {
-            // g_cs = *cs;
-            auto* aa = new Arena(ops);
-            uint64_t alloc_count_ = 1024;
-            for (uint64_t i = 0; i < alloc_count_; i++) {
-                alloc_success2 = (aa->AllocateAligned(10 * i) != nullptr);
-            }
-            delete aa;
-            local_arena_metrics.report_to_global_metrics();
-        };
+  { // multi-thread
+    bool alloc_success1 = false;
+    auto f1 = [=, this, &alloc_success1]() {
+      // g_cs = *cs;
+      auto *aa = new Arena(ops);
+      uint64_t alloc_count_ = 1024;
+      for (uint64_t i = 0; i < alloc_count_; i++) {
+        alloc_success1 = aa->AllocateAligned(10 * i).has_value();
+      }
+      delete aa;
+      local_arena_metrics.report_to_global_metrics();
+    };
+    bool alloc_success2 = false;
+    auto f2 = [=, this, &alloc_success2]() {
+      // g_cs = *cs;
+      auto *aa = new Arena(ops);
+      uint64_t alloc_count_ = 1024;
+      for (uint64_t i = 0; i < alloc_count_; i++) {
+        alloc_success2 = aa->AllocateAligned(10 * i).has_value();
+      }
+      delete aa;
+      local_arena_metrics.report_to_global_metrics();
+    };
 
-        auto& global = global_arena_metrics;
-        CHECK_EQ(global.init_count, 0);
-        CHECK_EQ(global.alloc_count, 0);
-        CHECK_EQ(global.destruct_count, 0);
+    auto &global = global_arena_metrics;
+    CHECK_EQ(global.init_count, 0);
+    CHECK_EQ(global.alloc_count, 0);
+    CHECK_EQ(global.destruct_count, 0);
 
-        std::thread t1(f1);
-        std::thread t2(f2);
-        t1.join();
-        t2.join();
+    std::thread t1(f1);
+    std::thread t2(f2);
+    t1.join();
+    t2.join();
 
-        CHECK(alloc_success1);
-        CHECK(alloc_success2);
-        CHECK_EQ(global.init_count, 2);
-        CHECK_EQ(global.alloc_count, alloc_count * 2);
-        CHECK_EQ(global.destruct_count, 2);
-        // std::cout << global.STring() << std::endl;
-    }
+    CHECK(alloc_success1);
+    CHECK(alloc_success2);
+    CHECK_EQ(global.init_count, 2);
+    CHECK_EQ(global.alloc_count, alloc_count * 2);
+    CHECK_EQ(global.destruct_count, 2);
+    // std::cout << global.STring() << std::endl;
+  }
 }
 
-}  // namespace arena
+} // namespace arena


### PR DESCRIPTION
## Summary
- Add `ArenaError` enum with error types: `AllocationFailed`, `OverflowDetected`, `CleanupFailed`, `ResourceInitFailed`
- Convert all allocation methods to return `Expected<T>` (`std::expected<T, ArenaError>`)
- Use monadic operations (`transform`, `and_then`) for cleaner error propagation
- Add `Arena::Make()` factory function returning `Expected<Arena>`
- Upgrade to C++23 for `std::expected` support

## Test plan
- [x] All 54 existing tests pass
- [x] Benchmarks run successfully with no performance regression
- [ ] Manual review of monadic chaining patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)